### PR TITLE
[Gravedigger] Add region checking to exit early

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.2'
+version = '2.2.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
@@ -125,6 +125,10 @@ public class GravediggerHelper
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
+		if (!RandomEventHelperPlugin.isInRandomEventLocalInstance(this.client))
+		{
+			return;
+		}
 		switch (varbitChanged.getVarbitId())
 		{
 			case VarbitID.MACRO_DIGGER_GRAVE_1: // Grave type/Gravestone
@@ -165,10 +169,10 @@ public class GravediggerHelper
 	@Subscribe
 	public void onGameObjectSpawned(GameObjectSpawned gameObjectSpawned)
 	{
-		GameObject gameObject = gameObjectSpawned.getGameObject();
 		// Pinball and grave digger random even locations are in region 7758
 		if (RandomEventHelperPlugin.isInRandomEventLocalInstance(this.client))
 		{
+			GameObject gameObject = gameObjectSpawned.getGameObject();
 			if (GraveNumber.isGravestoneObjectID(gameObject.getId()))
 			{
 				GraveNumber graveNumber = GraveNumber.getGraveNumberFromGravestoneObjectID(gameObject.getId());
@@ -267,7 +271,7 @@ public class GravediggerHelper
 	public void onItemContainerChanged(ItemContainerChanged itemContainerChanged)
 	{
 		// In case of unequipping an item -> INVENTORY -> EQUIPMENT changes
-		if (itemContainerChanged.getContainerId() == InventoryID.INV)
+		if (itemContainerChanged.getContainerId() == InventoryID.INV && RandomEventHelperPlugin.isInRandomEventLocalInstance(this.client))
 		{
 			this.currentInventoryItems.clear();
 			List<Item> itemStream = Arrays.stream(itemContainerChanged.getItemContainer().getItems()).filter(item -> item.getId() != -1).collect(Collectors.toList());


### PR DESCRIPTION
Added additional checks to avoid processing event code. Although perhaps for onVarbitChanged maybe it'll add to performance cost since I reckon int checks are much simpler than fetching client data like the players region.