### PR TITLE
Add media to various random events

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
 
 ## Supported Random Events
 ### [Surprise Exam](https://oldschool.runescape.wiki/w/Surprise%20Exam)
+<details>
+  <summary>Screenshot</summary>
+  <img width="1932" height="698" alt="image" src="https://github.com/user-attachments/assets/94df8805-414d-48fb-a7fb-7d4535080d6a" />
+</details>
+<details>
+  <summary>Video</summary>
+  
+  https://github.com/user-attachments/assets/793d3d0c-b31d-42fc-ae44-2891fc67f37a
+</details>
+
 - Highlights the correct answer for both the matching cards and next item sequence
   - Implemented via relations and keywords to hopefully support any variation of the questions/answers
     - As a result of using keywords, there could be a chance the solutions are incorrect. If this is the case, please open an issue on the [GitHub repository](https://github.com/Infinitay/Random-Event-Solver/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) with a screenshot of the random event question.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
 - No support for highlighting the raw pheasant drop itself
 
 ### [Drill Demon](https://oldschool.runescape.wiki/w/Drill%20Demon)
+<details>
+  <summary>Screenshot</summary>
+  <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/c35c23cc-5ae5-4d93-b185-a2cbf9bf7577" />
+</details>
+<details>
+  <summary>Video</summary>
+
+  https://github.com/user-attachments/assets/c1cdc8f9-1aec-40b2-ae08-8397c138139f
+</details>
+
 - Highlights the correct exercise mat to step on
 
 ### [Gravedigger](https://oldschool.runescape.wiki/w/Gravedigger)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
 - Displays the correct order to place the different hive piece
 
 ### [Pinball](https://oldschool.runescape.wiki/w/Pinball)
+<details>
+  <summary>Screenshot</summary>
+  <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/291a38f9-9c3d-49f8-8be6-218925076cc9" />
+</details>
+<details>
+  <summary>Video</summary>
+  
+  https://github.com/user-attachments/assets/221ee9a1-2557-4ef8-8ee1-7c6dc9361878
+</details>
+
 - Highlights the correct pillar to tag
   - The current event already tags the correct pillar, but this highlight will make it more obvious
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
     - _Disclaimer, the **relation matching system** was generated with AI, with me fixing the bugs and building upon the keywords._
 
 ### [Beekeeper](https://oldschool.runescape.wiki/w/Beekeeper_(Random_Event))
+<details>
+  <summary>Screenshot</summary>
+  <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/061a19ec-73bc-4841-8312-f362e99cc3a9" />
+</details>
+<details>
+  <summary>Video</summary>
+  
+  https://github.com/user-attachments/assets/23a1c491-03dd-44f5-886b-7875647be379
+</details>
 - Displays the correct order to place the different hive piece
 
 ### [Pinball](https://oldschool.runescape.wiki/w/Pinball)


### PR DESCRIPTION
### chore(pinball): Add Pinball media to README
- Added screenshots and videos for Pinball random event to the README

### chore(drilldemon): Add Drill Demon media to README

- Added screenshots and videos for Drill Demon random event to the README

### chore(beekeeper): Add Beekeeper media to README

- Added screenshots and videos for Beekeeper random event to the README

### chore(surpriseexam): Add Surprise Exam media to README

- Added screenshots and videos for Surprise Exam random event to the README