### PR TITLE
fix(drilldemon): Fix missing varbit data state for Drill Demon event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.4.1'
+version = '2.4.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'


### PR DESCRIPTION
There was an issue with the Drill Demon event clearing out the answers pre-emptively and also not having the right state when starting the module already inside the event. These changes adds an initialize check that initializes the data - which also clears the issue where RL doesn't fire VarbitChanged when a player logs in and a Varbit value is 0 (because it didn't necessarily change).

- Added initialization for varbit data state
	- Fixes plugin not working when starting already inside the event
	- Helps with edge-case where another player's invalidates state
- Improved dialogue handling for better reliability and clearing state
- Updated plugin to 2.4.2