### PR TITLE
[Freaky Forester] Fix unwanted clearing pheasants and update regex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.4.2'
+version = '2.4.3'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
@@ -1,6 +1,7 @@
 package randomeventhelper.randomevents.freakyforester;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.Map;
@@ -12,8 +13,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.WidgetLoaded;
@@ -25,6 +28,8 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.randomevents.drilldemon.DrillExercise;
 
 @Slf4j
 @Singleton
@@ -45,9 +50,10 @@ public class FreakyForesterHelper
 	@Inject
 	private FreakyForesterOverlay freakyForesterOverlay;
 
-	private final String FREAKY_FORESTER_REGEX = "Could you kill a pheasant with (?<numberOfTails>\\d+) tails";
+	private final String FREAKY_FORESTER_REGEX = "kill (a|the) (((?<numberOfTails>\\d)-tailed pheasant)|pheasant (with|that has) (?<numberOfTailsMulti>\\w+|\\d) tails)";
 	private final Pattern FREAKY_FORESTER_PATTERN = Pattern.compile(FREAKY_FORESTER_REGEX, Pattern.CASE_INSENSITIVE);
 
+	@Getter
 	private int pheasantTailFeathers;
 
 	@Getter
@@ -77,45 +83,45 @@ public class FreakyForesterHelper
 	}
 
 	@Subscribe
-	public void onWidgetLoaded(WidgetLoaded widgetLoaded)
+	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if (widgetLoaded.getGroupId() == InterfaceID.CHAT_LEFT)
+		String sanitizedChatMessage = Text.sanitizeMultilineText(chatMessage.getMessage());
+		if (chatMessage.getType() == ChatMessageType.DIALOG)
 		{
-			this.clientThread.invokeLater(() -> {
-				Widget chatboxTextWidget = this.client.getWidget(InterfaceID.ChatLeft.TEXT);
-				if (chatboxTextWidget != null)
+			if (this.isInFreakyForesterInstance())
+			{
+				Matcher freakyForesterMatcher = FREAKY_FORESTER_PATTERN.matcher(sanitizedChatMessage);
+
+				if (freakyForesterMatcher.find())
 				{
-					String chatboxText = Text.sanitizeMultilineText(chatboxTextWidget.getText());
-					if (chatboxText != null && !chatboxText.isEmpty())
+					String fullMatch = freakyForesterMatcher.group(0);
+					if (freakyForesterMatcher.group("numberOfTails") != null)
 					{
-						log.debug("Chatbox text loaded: {}", chatboxText);
-						Matcher freakyForesterMatcher = FREAKY_FORESTER_PATTERN.matcher(chatboxText);
-
-						if (freakyForesterMatcher.find())
-						{
-							String fullMatch = freakyForesterMatcher.group(0);
-							this.pheasantTailFeathers = Integer.parseInt(freakyForesterMatcher.group("numberOfTails"));
-
-							System.out.println("Full match: " + fullMatch);
-							System.out.println("Number of tails: " + this.pheasantTailFeathers);
-							// <1, NpcID.MACRO_PHEASANT_MODEL_1>, <2, NpcID.MACRO_PHEASANT_MODEL_2>, <3, NpcID.MACRO_PHEASANT_MODEL_3>, <4, NpcID.MACRO_PHEASANT_MODEL_4>
-							this.pheasantNPC = this.client.getTopLevelWorldView().npcs().stream().filter(npc -> npc.getId() == PHEASANT_TAIL_NPCID_MAP.get(this.pheasantTailFeathers)).collect(Collectors.toSet());
-						}
+						// Should only match 2/3/4
+						this.pheasantTailFeathers = Integer.parseInt(freakyForesterMatcher.group("numberOfTails"));
 					}
 					else
 					{
-						log.warn("Chatbox text is empty or null.");
-						this.pheasantNPC = Sets.newHashSet();
-						this.pheasantTailFeathers = 0;
+						// Could be 2/3/4 or two/three/four
+						try
+						{
+							this.pheasantTailFeathers = Integer.parseInt(freakyForesterMatcher.group("numberOfTailsMulti"));
+						}
+						catch (NumberFormatException e)
+						{
+							this.pheasantTailFeathers = this.convertWordToInt(freakyForesterMatcher.group("numberOfTailsMulti"));
+						}
 					}
+					log.info("Freaky Forester requested a pheasant with {} tail feathers", this.pheasantTailFeathers);
+					log.debug("Full match: {}", fullMatch);
+					// <1, NpcID.MACRO_PHEASANT_MODEL_1>, <2, NpcID.MACRO_PHEASANT_MODEL_2>, <3, NpcID.MACRO_PHEASANT_MODEL_3>, <4, NpcID.MACRO_PHEASANT_MODEL_4>
+					this.pheasantNPC = this.client.getTopLevelWorldView().npcs().stream().filter(npc -> npc.getId() == PHEASANT_TAIL_NPCID_MAP.get(this.pheasantTailFeathers)).collect(Collectors.toSet());
 				}
 				else
 				{
-					log.warn("Chatbox text widget is null.");
-					this.pheasantNPC = Sets.newHashSet();
 					this.pheasantTailFeathers = 0;
 				}
-			});
+			}
 		}
 	}
 
@@ -143,11 +149,31 @@ public class FreakyForesterHelper
 	@Subscribe
 	public void onNpcDespawned(NpcDespawned npcDespawned)
 	{
-		if (npcDespawned.getNpc().getId() == NpcID.MACRO_FORESTER_M)
+		if (npcDespawned.getNpc().getId() == NpcID.MACRO_FORESTER_M && !this.isInFreakyForesterInstance())
 		{
 			log.debug("Freaky Forester NPC despawned, resetting pheasant NPCs.");
 			this.pheasantTailFeathers = 0;
 			this.pheasantNPC.clear();
+		}
+	}
+
+	private boolean isInFreakyForesterInstance()
+	{
+		return RandomEventHelperPlugin.getRegionIDFromCurrentLocalPointInstanced(client) == 10314;
+	}
+
+	private int convertWordToInt(String word)
+	{
+		switch (word)
+		{
+			case "two":
+				return 2;
+			case "three":
+				return 3;
+			case "four":
+				return 4;
+			default:
+				return 0;
 		}
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterOverlay.java
@@ -32,7 +32,7 @@ public class FreakyForesterOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics2D)
 	{
-		if (plugin.getPheasantNPC() != null && !plugin.getPheasantNPC().isEmpty())
+		if (plugin.getPheasantTailFeathers() != 0 || plugin.getPheasantNPC() != null && !plugin.getPheasantNPC().isEmpty())
 		{
 			for (NPC pheasantNPC : plugin.getPheasantNPC())
 			{


### PR DESCRIPTION
- Fixed clearing Pheasant NPCs when an edge case of another player's Freaky Forester NPC despawns
- Updated regex to handle multiple dialogue forms indicating the required pheasant
- Refactored the Helper plugin to use ChatMessage events instead of WidgetLoaded
- Added accessor to `pheasantTailFeathers` to avoid rendering NPCs when not having to resolving a NPE
- Update plugin to v2.4.3