### PR TITLE
chore: Add missing plugin tags for various events

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,5 @@
 displayName=Random Event Helper
 author=infinitay
 description=A plugin to help solve various random events
-tags=random,event,helper,solver,exam,surprise exam,quiz,bee,beehive,beekeeper,freaky forester,pheasant,pinball,flippa,drill demon,damien,exercise,gravedigger,coffin
+tags=random,event,helper,solver,exam,surprise exam,quiz,bee,beehive,beekeeper,freaky forester,pheasant,pinball,flippa,drill demon,damien,exercise,gravedigger,coffin,mime,mysterious old man,maze,quiz master,odd one out,sandwich lady,baguette,capt arnav,captain arnav chest
 plugins=randomeventshelper.RandomEventHelperPlugin


### PR DESCRIPTION
Added various tags to the plugin property for the following events:
- Mime
- Maze
- Quiz Master
- Sandwich Lady
- Capt Arnav Chest