### PR TITLE
fix: Fix wrong plugin class within RL Plugin Properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,4 +2,4 @@ displayName=Random Event Helper
 author=infinitay
 description=A plugin to help solve various random events
 tags=random,event,helper,solver,exam,surprise exam,quiz,bee,beehive,beekeeper,freaky forester,pheasant,pinball,flippa,drill demon,damien,exercise,gravedigger,coffin,mime,mysterious old man,maze,quiz master,odd one out,sandwich lady,baguette,capt arnav,captain arnav chest
-plugins=randomeventshelper.RandomEventHelperPlugin
+plugins=randomeventhelper.RandomEventHelperPlugin


### PR DESCRIPTION
https://github.com/runelite/plugin-hub/actions/runs/17813554453/job/50663021323?pr=9083

Plugin failed to build when submitted to the Plugin Hub. When I refactored the project I forgot to change the plugin value within runelite-plugin.properties. This should fix it now.