### PR TITLE
refactor(maze): Remove auto enabling of Shortest Path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.5.2'
+version = '2.5.3'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
@@ -51,9 +51,8 @@ public class MazeHelper
 		{
 			if (!pluginManager.isPluginEnabled(shortestPathPlugin.get()))
 			{
-				log.warn("[#onStartUp] ShortestPathPlugin is not enabled, turning it on to ensure functionality");
-				this.client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Enabling Shortest Path plugin for Maze Helper functionality.", null);
-				pluginManager.setPluginEnabled(shortestPathPlugin.get(), true);
+				log.warn("[#onStartUp] ShortestPathPlugin is not enabled. Please enable it manually to ensure maze helper's functionality.");
+				this.client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "[Random Event Helper] You've enabled the maze helper module but have the Shortest Path plugin disabled. Please enable it manually to ensure functionality.", null);
 			}
 		}
 		else


### PR DESCRIPTION
### refactor(maze): Remove auto enabled Shortest Path, Update chat message
- Removed the feature that auto-enabled Shorest Path plugin when installed but disabled for the maze helper
- Updated the chat message to instruct the user they have to manually enable it
- Update plugin to v2.5.3

_Context: https://github.com/runelite/plugin-hub/pull/9083#issuecomment-3482579322_