### PR TITLE
[Surprise Exam] Add unit testing for the relationship system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.5.3'
+version = '2.5.4'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     testRuntimeOnly group: "org.junit.platform", name: "junit-platform-launcher", version: "1.5.2"
 
     // For RelationshipSystem testing - specifically for list comparisons
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.27.6'
 
     testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,29 @@ def runeLiteVersion = 'latest.release'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.30'
-	annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-	testImplementation 'junit:junit:4.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+    // Credit to Dink Plugin
+    // max version before junit-bom was added to pom files, due to runelite restrictions
+    def junitVersion = "5.5.2"
+
+    testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: junitVersion
+    testImplementation group: "org.junit.jupiter", name: "junit-jupiter-params", version: junitVersion
+    testImplementation group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
+    testRuntimeOnly group: "org.junit.platform", name: "junit-platform-launcher", version: "1.5.2"
+
+    // For RelationshipSystem testing - specifically for list comparisons
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+
+    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+}
+
+test {
+    useJUnitPlatform()
 }
 
 group = 'randomeventhelper'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.5.4'
+version = '2.5.5'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.5.5'
+version = '2.5.6'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -196,7 +196,7 @@ public class OSRSItemRelationshipSystem
 		));
 
 		map.put(RelationshipType.FOOT_ARMOR, Set.of(
-			RandomEventItem.BOOTS, RandomEventItem.PIRATE_BOOTS, RandomEventItem.LEATHER_BOOTS,
+			RandomEventItem.INSULATED_BOOTS, RandomEventItem.PIRATE_BOOTS, RandomEventItem.LEATHER_BOOTS,
 			RandomEventItem.FIGHTER_BOOTS
 		));
 

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RandomEventItem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RandomEventItem.java
@@ -87,7 +87,7 @@ public enum RandomEventItem
 	SHEARS(41227),
 	SHORT_BOW(41171),
 	SHRIMP(41147),
-	BOOTS(27104),
+	INSULATED_BOOTS(27104),
 	FIGHTER_BOOTS(41160),
 	SPADE(41155),
 	SQUARE_SHIELD_2(41169),
@@ -127,5 +127,11 @@ public enum RandomEventItem
 		}
 
 		ITEM_MODEL_ID_MAP = itemModelIDBuilder.build();
+	}
+
+	@Override
+	public String toString()
+	{
+		return this.name() + " ("+ modelID + ")";
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
@@ -140,6 +140,7 @@ public class SurpriseExamHelper
 					log.debug("Exam hint widget loaded with text: {}", examHint);
 					if (examHint != null && !examHint.isEmpty())
 					{
+						log.debug("Exam available pattern card items: {}", this.getPatternCardMap().values().asList());
 						List<RandomEventItem> answerItems = this.relationshipSystem.findItemsByHint(examHint, this.getPatternCardMap().values().asList(), 3);
 						log.debug("Found answer items for exam hint '{}': {}", examHint, answerItems);
 						if (answerItems.size() >= 3)
@@ -159,7 +160,6 @@ public class SurpriseExamHelper
 								.filter(Objects::nonNull)
 								.collect(ImmutableSet.toImmutableSet());
 							log.debug("Pattern card answers set to: {}", this.patternCardAnswers);
-							log.debug("Pattern card answer widgets set to: {}", this.patternCardAnswerWidgets);
 						}
 						else
 						{
@@ -197,7 +197,6 @@ public class SurpriseExamHelper
 							Integer interfaceID = getKeyForValue(this.getPatternNextChoicesMap(), answerItem);
 							this.patternNextAnswerWidget = interfaceID != null ? this.client.getWidget(interfaceID) : null;
 							log.debug("Pattern next answer set to: {}", this.patternNextAnswer);
-							log.debug("Pattern next answer widget set to: {}", this.patternNextAnswerWidget);
 						}
 						else
 						{
@@ -326,4 +325,3 @@ public class SurpriseExamHelper
 		return null;
 	}
 }
-

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
@@ -194,6 +194,8 @@ public class SurpriseExamHelper
 					{
 						List<RandomEventItem> initialSelectionItems = this.getPatternNextInitialSelectionMap().values().asList();
 						List<RandomEventItem> choicesItems = this.getPatternNextChoicesMap().values().asList();
+						log.debug("Exam next initial selection items: {}", initialSelectionItems);
+						log.debug("Exam next choice items: {}", choicesItems);
 						RandomEventItem answerItem = this.relationshipSystem.findMissingItem(initialSelectionItems, choicesItems);
 						if (answerItem != null)
 						{
@@ -257,19 +259,19 @@ public class SurpriseExamHelper
 		if (executedCommand.getCommand().equalsIgnoreCase("exportexampuzzle"))
 		{
 			StringBuilder sb = new StringBuilder();
-			sb.append("Pattern Card Available Items: ");
+			sb.append("Pattern Card Matching Available Items: ");
 			sb.append(this.getPatternCardMap() != null ? this.getPatternCardMap().values().asList().toString() : "NULL");
 			sb.append("\n");
-			sb.append("Pattern Card Calculated Answers: ");
+			sb.append("Pattern Card Matching Calculated Answers: ");
 			sb.append(this.patternCardAnswers != null ? this.patternCardAnswers.toString() : "NULL");
 			sb.append("\n");
-			sb.append("Pattern Next Initial Items: ");
+			sb.append("Pattern Next Item Initial Items: ");
 			sb.append(this.getPatternNextInitialSelectionMap() != null ? this.getPatternNextInitialSelectionMap().values().asList().toString() : "NULL");
 			sb.append("\n");
-			sb.append("Pattern Next Choices: ");
+			sb.append("Pattern Next Item Choices: ");
 			sb.append(this.getPatternNextChoicesMap() != null ? this.getPatternNextChoicesMap().values().asList().toString() : "NULL");
 			sb.append("\n");
-			sb.append("Pattern Next Calculated Answer: ");
+			sb.append("Pattern Next Item Calculated Answer: ");
 			sb.append(this.patternNextAnswer != null ? this.patternNextAnswer.toString() : "NULL");
 			Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 			clipboard.setContents(new StringSelection(sb.toString()), null);

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -1,17 +1,89 @@
 package randomeventhelper;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import randomeventhelper.randomevents.surpriseexam.OSRSItemRelationshipSystem;
+import randomeventhelper.randomevents.surpriseexam.RandomEventItem;
 
 public class RelationshipSystemTest
 {
+	OSRSItemRelationshipSystem relationshipSystem = new OSRSItemRelationshipSystem();
+
 	@Test
-	public void testPatternMatching() {
-		Assert.assertTrue(true);
+	public void testPatternMatching()
+	{
+		RelationshipSystemTestMatchingData puzzle1 = new RelationshipSystemTestMatchingData(
+			"I feel like a fish out of water!",
+			"[BATTLE_AXE (41176), NECKLACE (41216), CANDLE_LANTERN (41229), CAPE_OF_LEGENDS (41167), RAKE (41212), ONION (41226), HARPOON (41158), RING (27091), FIGHTER_BOOTS (41160), HAMMER (41183), MED_HELM (41189), BEER (41152), TROUT_COD_PIKE_SALMON_4 (41217), TROUT_COD_PIKE_SALMON_3 (41163), AIR_RUNE (41168)]",
+			List.of(RandomEventItem.HARPOON, RandomEventItem.TROUT_COD_PIKE_SALMON_4, RandomEventItem.TROUT_COD_PIKE_SALMON_3)
+		);
+		List<RandomEventItem> puzzle1ActualItems = relationshipSystem.findItemsByHint(puzzle1.getHint(), puzzle1.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle1ActualItems).containsExactlyInAnyOrderElementsOf(puzzle1.getExpectedMatchingItems());
 	}
 
 	@Test
-	public void testNextMissingItem() {
-		Assert.assertTrue(true);
+	public void testNextMissingItem()
+	{
+		// initial sequence: BREAD, CAKE, PIE | given: PIZZA, ESSENCE, ARROW, BOOT | expected: PIZZA
+		RelationshipSystemTestNextMissingItemData puzzle1 = new RelationshipSystemTestNextMissingItemData(
+			"[BREAD (41172), CAKE (41202), PIE (41205)]",
+			"[PIZZA (41185), RUNE_OR_ESSENCE (41182), ARROWS (41177), LEATHER_BOOTS (41220)]",
+			RandomEventItem.PIZZA
+		);
+		RandomEventItem puzzle1ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle1.getInitialSequenceItems(), puzzle1.getItemChoices());
+		Assertions.assertThat(puzzle1ActualNextMissingItem).isEqualTo(puzzle1.getExpectedNextMissingItem());
+	}
+
+	@Data
+	static class RelationshipSystemTestMatchingData
+	{
+		private String hint;
+		private List<RandomEventItem> givenItems;
+		private List<RandomEventItem> expectedMatchingItems;
+
+		public RelationshipSystemTestMatchingData(String hint, String givenItemsDebugString, List<RandomEventItem> expectedMatchingItems)
+		{
+			this.hint = hint;
+			this.givenItems = fromDebugString(givenItemsDebugString);
+			this.expectedMatchingItems = expectedMatchingItems;
+		}
+	}
+
+	@Data
+	static class RelationshipSystemTestNextMissingItemData
+	{
+		private List<RandomEventItem> initialSequenceItems;
+		private List<RandomEventItem> itemChoices;
+		private RandomEventItem expectedNextMissingItem;
+
+		public RelationshipSystemTestNextMissingItemData(String initialSequenceItemsDebugString, String givenItemsDebugString, RandomEventItem expectedNextMissingItem)
+		{
+			this.initialSequenceItems = fromDebugString(initialSequenceItemsDebugString);
+			this.itemChoices = fromDebugString(givenItemsDebugString);
+			this.expectedNextMissingItem = expectedNextMissingItem;
+		}
+	}
+
+	/**
+	 * Converts a string into a list of @{@link RandomEventItem}
+	 *
+	 * @param debugString A comma-separated string of @{@link RandomEventItem} names (eg. [BATTLE_AXE (41176), NECKLACE (41216), CANDLE_LANTERN (41229), CAPE_OF_LEGENDS (41167), RAKE (41212), ONION (41226), HARPOON (41158), RING (27091), FIGHTER_BOOTS (41160), HAMMER (41183), MED_HELM (41189), BEER (41152), TROUT_COD_PIKE_SALMON_4 (41217), TROUT_COD_PIKE_SALMON_3 (41163), AIR_RUNE (41168)]
+	 * @return List of associated {@link RandomEventItem}s
+	 */
+	private static List<RandomEventItem> fromDebugString(String debugString)
+	{
+		// Sanitize the string to remove brackets
+		debugString = debugString.replace("[", "").replace("]", "");
+		List<RandomEventItem> randomEventItems = new ArrayList<>();
+		String[] separatedItems = debugString.split(",");
+		for (String randomEventItem : separatedItems)
+		{
+			String itemName = randomEventItem.trim().split(" ")[0];
+			randomEventItems.add(RandomEventItem.valueOf(itemName));
+		}
+		return randomEventItems;
 	}
 }

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -1,0 +1,17 @@
+package randomeventhelper;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RelationshipSystemTest
+{
+	@Test
+	public void testPatternMatching() {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testNextMissingItem() {
+		Assert.assertTrue(true);
+	}
+}


### PR DESCRIPTION
WIP PR to add unit testing for Surprise Exam modules relationship system for solving the pattern matching and next item puzzles. 

Related issue: #28 

### test(surpriseexam): Initiated unit testing for Surprise Exam (OSRSItemRelationshipSystem)

### refactor(surpriseexam): Renam REI.BOOTS to INSULATED_BOOTS, RandomEventItem#toString, logging changes
- Cleaned up and added debug logging in SurpriseExamHelper
- Renamed RandomEventItem.BOOTS to INSULATED_BOOTS in RandomEventItem and refactored OSRSItemRelationshipSystem to reflect the changes
- Added #toString override in RandomEventItem to include the name and model ID of the item
- Update plugin to v2.5.4

### test(surpriseexam): Updated gradle build dependencies, migrated to AssertJ, added tests
- Updated gradle build test dependencies
    - Added lombok to test dependencies and added new test dependency AssertJ
    - Upgraded to JUnit 5
    - Specify to `useJUnitPlatform` for test task
- Refactored RelationshipSystemTest to use AssertJ
- Added basic tests for pattern matching and next missing item
- Added data classes and a helper method to map the debug string from the Surprise Exam module to a RandomEventItem list


