### PR TITLE
[Surprise Exam] Fix headgear and melee armor puzzles (#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.5.6'
+version = '2.5.7'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -205,6 +205,13 @@ public class OSRSItemRelationshipSystem
 			RandomEventItem.KITESHIELD, RandomEventItem.WOODEN_SHIELD
 		));
 
+		map.put(RelationshipType.MELEE_GEAR, Set.of(
+			RandomEventItem.BATTLE_AXE, RandomEventItem.LONGSWORD, RandomEventItem.MACE,
+			RandomEventItem.SCIMITAR, RandomEventItem.FULL_HELM, RandomEventItem.MED_HELM, RandomEventItem.PLATEBODY,
+			RandomEventItem.PLATELEGS, RandomEventItem.SQUARE_SHIELD_1, RandomEventItem.SQUARE_SHIELD_2,
+			RandomEventItem.KITESHIELD, RandomEventItem.WOODEN_SHIELD
+		));
+
 		map.put(RelationshipType.JEWELRY_ACCESSORIES, Set.of(
 			RandomEventItem.NECKLACE, RandomEventItem.RING, RandomEventItem.HOLY_SYMBOL,
 			RandomEventItem.CAPE_OF_LEGENDS

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RandomEventItem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RandomEventItem.java
@@ -105,7 +105,6 @@ public enum RandomEventItem
 	WATERMELON_SLICE(41156),
 	WATER_RUNE(41231),
 	BONES(2674),
-
 	KEY(29232);
 
 	private final int modelID;

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -16,19 +16,20 @@ public enum RelationshipType
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),
 
 	// Thematic groups
-	PIRATE_THEME("pirate, sea, nautical, hook, eyepatch, boots, hat, yarr, crime"),
-	ENTERTAINMENT_THEME("entertainment, performance, jester, mime, mask, fun, clown, fool, mask, face"),
+	PIRATE_THEME("pirate, sea, nautical, hook, eyepatch, boots, hat, yarr, crime, strange"),
+	ENTERTAINMENT_THEME("entertainment, performance, jester, mime, mask, fun, clown, fool, mask, face, strange"),
 	PROFESSIONAL_THEME("profession, work, chef, trade, job, occupation"),
 
 	// Equipment categories
 	MELEE_WEAPONS("melee, sword, axe, mace, scimitar, close, combat, sharp"),
 	RANGED_WEAPONS("ranged, bow, crossbow, arrows, ammunition, distance, sharp"),
 	MAGIC_RUNES("runes, elemental, air, earth, fire, water, magic, abracadabra, hocus pocus"),
-	HEAD_ARMOR("head, helmet, hat, protection, headwear, skull, mask"),
+	HEAD_ARMOR("head, helmet, hat, protection, headwear, skull, mask, headgear"),
 	BODY_ARMOR("body, chest, torso, platebody, apron, protection"),
 	LEG_ARMOR("legs, platelegs, protection, lower, body"),
 	FOOT_ARMOR("feet, boots, footwear, walking, protection"),
 	SHIELDS("shield, defense, blocking, protection, guard"),
+	MELEE_GEAR("melee, sword, scimitar, axe, mace, combat, sharp, helmet, platebody, platelegs, shield"),
 	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, cape, status"),
 	FACE_ACCESSORIES("face, mask, eyepatch, hook, covering, facial"),
 

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
@@ -46,6 +46,8 @@ public class SurpriseExamHelper
 	@Inject
 	private SurpriseExamOverlay overlay;
 
+	private String patternCardHint;
+
 	@Getter
 	private ImmutableSet<RandomEventItem> patternCardAnswers;
 
@@ -113,6 +115,7 @@ public class SurpriseExamHelper
 	{
 		this.eventBus.register(this);
 		this.overlayManager.add(overlay);
+		this.patternCardHint = null;
 		this.patternCardAnswers = null;
 		this.patternCardAnswerWidgets = null;
 		this.patternNextAnswer = null;
@@ -124,6 +127,7 @@ public class SurpriseExamHelper
 	{
 		this.eventBus.unregister(this);
 		this.overlayManager.remove(overlay);
+		this.patternCardHint = null;
 		this.patternCardAnswers = null;
 		this.patternCardAnswerWidgets = null;
 		this.patternNextAnswer = null;
@@ -140,13 +144,13 @@ public class SurpriseExamHelper
 				Widget examHintWidget = this.client.getWidget(InterfaceID.PatternCards.HINT);
 				if (examHintWidget != null)
 				{
-					String examHint = examHintWidget.getText();
-					log.debug("Exam hint widget loaded with text: {}", examHint);
-					if (examHint != null && !examHint.isEmpty())
+					this.patternCardHint = examHintWidget.getText();
+					log.debug("Exam hint widget loaded with text: {}", this.patternCardHint);
+					if (this.patternCardHint != null && !this.patternCardHint.isEmpty())
 					{
 						log.debug("Exam available pattern card items: {}", this.getPatternCardMap().values().asList());
-						List<RandomEventItem> answerItems = this.relationshipSystem.findItemsByHint(examHint, this.getPatternCardMap().values().asList(), 3);
-						log.debug("Found answer items for exam hint '{}': {}", examHint, answerItems);
+						List<RandomEventItem> answerItems = this.relationshipSystem.findItemsByHint(this.patternCardHint, this.getPatternCardMap().values().asList(), 3);
+						log.debug("Found answer items for exam hint '{}': {}", this.patternCardHint, answerItems);
 						if (answerItems.size() >= 3)
 						{
 							this.patternCardAnswers = ImmutableSet.copyOf(answerItems);
@@ -167,7 +171,7 @@ public class SurpriseExamHelper
 						}
 						else
 						{
-							log.warn("Found {} items for exam hint '{}', expected 3.", answerItems.size(), examHint);
+							log.warn("Found {} items for exam hint '{}', expected 3.", answerItems.size(), this.patternCardHint);
 							this.patternCardAnswers = null;
 							this.patternCardAnswerWidgets = null;
 						}
@@ -175,6 +179,7 @@ public class SurpriseExamHelper
 					else
 					{
 						log.warn("Exam hint widget text is empty or null.");
+						this.patternCardHint = null;
 						this.patternCardAnswers = null;
 						this.patternCardAnswerWidgets = null;
 					}
@@ -228,6 +233,7 @@ public class SurpriseExamHelper
 		if (widgetClosed.getGroupId() == InterfaceID.PATTERN_CARDS)
 		{
 			log.debug("Pattern cards widget closed, resetting pattern card answers.");
+			this.patternCardHint = null;
 			this.patternCardAnswers = null;
 			this.patternCardAnswerWidgets = null;
 		}
@@ -246,6 +252,7 @@ public class SurpriseExamHelper
 		if (npcDespawned.getNpc().getId() == NpcID.PATTERN_TEACHER)
 		{
 			log.debug("Mr. Mordaut NPC despawned, resetting all answers.");
+			this.patternCardHint = null;
 			this.patternCardAnswers = null;
 			this.patternCardAnswerWidgets = null;
 			this.patternNextAnswer = null;
@@ -259,6 +266,9 @@ public class SurpriseExamHelper
 		if (executedCommand.getCommand().equalsIgnoreCase("exportexampuzzle"))
 		{
 			StringBuilder sb = new StringBuilder();
+			sb.append("Pattern Card Matching Hint: ");
+			sb.append(this.patternCardHint != null ? this.patternCardHint : "NULL");
+			sb.append("\n");
 			sb.append("Pattern Card Matching Available Items: ");
 			sb.append(this.getPatternCardMap() != null ? this.getPatternCardMap().values().asList().toString() : "NULL");
 			sb.append("\n");

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -22,6 +22,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle1ActualItems = relationshipSystem.findItemsByHint(puzzle1.getHint(), puzzle1.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle1ActualItems).containsExactlyInAnyOrderElementsOf(puzzle1.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle2 = new RelationshipSystemTestMatchingData(
+			"Some professions use such strange headgear.",
+			"[CAKE (41202), TROUT_COD_PIKE_SALMON_4 (41217), SHARK (41166), ARROWS (41177), TINDERBOX (41154), HERRING_OR_MACKEREL (41193), PLATELEGS (41179), ORE (41170), LEDERHOSEN_HAT (41164), LONGSWORD (41150), BONES (2674), POT (41223), PIRATE_HAT (41187), JESTER_HAT (41196), AXE (41184)]",
+			List.of(RandomEventItem.LEDERHOSEN_HAT, RandomEventItem.PIRATE_HAT, RandomEventItem.JESTER_HAT)
+		);
+		List<RandomEventItem> puzzle2ActualItems = relationshipSystem.findItemsByHint(puzzle2.getHint(), puzzle2.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle2ActualItems).containsExactlyInAnyOrderElementsOf(puzzle2.getExpectedMatchingItems());
 	}
 
 	@Test
@@ -35,6 +43,14 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle1ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle1.getInitialSequenceItems(), puzzle1.getItemChoices());
 		Assertions.assertThat(puzzle1ActualNextMissingItem).isEqualTo(puzzle1.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle2 = new RelationshipSystemTestNextMissingItemData(
+			"[LONGSWORD (41150), FULL_HELM (41178), KITESHIELD (41200)]",
+			"[EARTH_RUNE (41157), BAR (41153), PLATEBODY (27094), CAKE (41202)]",
+			RandomEventItem.PLATEBODY
+		);
+		RandomEventItem puzzle2ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle2.getInitialSequenceItems(), puzzle2.getItemChoices());
+		Assertions.assertThat(puzzle2ActualNextMissingItem).isEqualTo(puzzle2.getExpectedNextMissingItem());
 	}
 
 	@Data


### PR DESCRIPTION
This PR fixes two incorrect Surprise Exam puzzles (#28):

- Card matching involving the hint "Some professions use such strange headgear" -> lederhosen hat, pirate hat, jester hat (was selecting fishes and a jester hat in a user report)
- Next/missing item in the sequence: _Sword, full helm, platebody_ -> Platebody (was cake in user issue, but in local testing it was bar)

Additionally, it adds to the `::exportexampuzzle` command by now exporting the matching puzzle hint which was missing.

---

### feat(surpriseexam): Add card matching hint to export command

- Track the card matching puzzle hint with `patternCardHint` instead of a local variable
- Add logging for the card matching puzzle hint to the `exportexampuzzle` chat command within onCommandExecuted


### feat(surpriseexam): Update RelationshipType, add MELEE_GEAR type (#28)
- Update existing enums within RelationshipType and add new MELEE_GEAR type
	- Added new keywords for PIRATE_THEME, ENTERTAINMENT_THEME, and HEAD_ARMOR (fixes #28 headgear hint)
	- Added new type MELEE_GEAR to resolve (fixes #28 next missing melee gear item)
- Add new relationship within OSRSItemRelationshipSystem for MELEE_GEAR (fixes #28 next missing melee gear item)
- Remove extra newline within RandomEventItem
- Add additional RelationshipSystem tests (#28)


### chore: Update plugin to v2.5.7 (#28)
- Added card matching puzzle hint to the export command
- Updated various RelationshipType keywords
- Added new RelationshipType.MELEE_GEAR
- Updated plugin to v2.5.7