### PR TITLE
[Gravedigger] Better initial starts and more highlight modes (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
 
 - Displays the correct coffin solution for all the graves via color-coded highlights
 - Swaps "Use" to be the first option on a coffin
+- View either skill icons or item icons related to the grave
 
 ### [Mime](https://oldschool.runescape.wiki/w/Mime_(Random_Event))
 <details>

--- a/README.md
+++ b/README.md
@@ -87,15 +87,27 @@ A RuneLite plugin to help solve random events by displaying solutions for each r
 ### [Gravedigger](https://oldschool.runescape.wiki/w/Gravedigger)
 <details>
   <summary>Screenshot</summary>
+
+  _Prior to highlight modes being added_
   <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/14b231e7-2a89-462b-97ce-ec2192d7b889" />
 </details>
 <details>
   <summary>Video</summary>
-  
-  https://github.com/user-attachments/assets/98b599e4-1ba2-4ba8-a22f-ffc9934db0e7
+
+  https://github.com/user-attachments/assets/a911d686-5b0c-43c8-b6a6-9ba45bea7b63
 </details>
 
-- Displays the correct coffin solution for all the graves via color-coded highlights
+- Displays the correct coffin solution for all the graves
+
+    | Mode             | Description                                                 |
+    |------------------|-------------------------------------------------------------|
+    | Gravestone Icon  | Shows the respective skill/item icon related to the grave   |
+    | Coffin Icon      | Shows the respective skill/item icon related to the coffin  |
+    | Highlight Grave  | Highlights the grave and gravestone with a respective color |
+    | Highlight Coffin | Highlights the coffin with a respective color               |
+    | Grave Text       | Displays a text associated with the grave                   |
+    | Coffin Text      | Displays a text associated with the coffin                  |
+  - Keep in mind you are able to select none or multiple modes at once (CTRL + Click to select multiple or to deselect)
 - Swaps "Use" to be the first option on a coffin
 - View either skill icons or item icons related to the grave
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.5.12'
+version = '2.6.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/RandomEventHelperConfig.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperConfig.java
@@ -42,11 +42,20 @@ public interface RandomEventHelperConfig extends Config
 		return true;
 	}
 
+	@ConfigSection(
+		name = "Freaky Forester",
+		description = "Freaky Forester random event options",
+		position = 3,
+		closedByDefault = true
+	)
+	String SECTION_FREAKY_FORESTER = "sectionFreakyForester";
+
 	@ConfigItem(
 		keyName = "isFreakyForesterEnabled",
 		name = "Freaky Forester",
 		description = "Helps highlight the correct pheasant to kill for the Freaky Forester random event.",
-		position = 3
+		section = SECTION_FREAKY_FORESTER,
+		position = 0
 	)
 	default boolean isFreakyForesterEnabled()
 	{
@@ -54,12 +63,45 @@ public interface RandomEventHelperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "pheasantHighlightMode",
+		name = "Pheasant Highlight Mode",
+		description = "Configures how to highlight the pheasant(s) for the Freaky Forester random event.",
+		section = SECTION_FREAKY_FORESTER,
+		position = 1
+	)
+	default PheasantMode pheasantHighlightMode()
+	{
+		return PheasantMode.SPECIFIC;
+	}
+
+	@ConfigSection(
+		name = "Gravedigger",
+		description = "Gravedigger random event options",
+		position = 4,
+		closedByDefault = true
+	)
+	String SECTION_GRAVEDIGGER = "sectionGravedigger";
+
+	@ConfigItem(
 		keyName = "isGravediggerEnabled",
 		name = "Gravedigger",
 		description = "Helps highlight where each coffin belongs to each grave for the Gravedigger random event.",
-		position = 4
+		section = SECTION_GRAVEDIGGER,
+		position = 0
 	)
 	default boolean isGravediggerEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "gravediggerUseSkillIcons",
+		name = "Use skill icons instead of item icons",
+		description = "Use the associated skill icons instead of item icons for gravestones and coffins in the Gravedigger random event.",
+		section = SECTION_GRAVEDIGGER,
+		position = 1
+	)
+	default boolean gravediggerUseSkillIcons()
 	{
 		return true;
 	}
@@ -128,25 +170,5 @@ public interface RandomEventHelperConfig extends Config
 	default boolean isQuizMasterEnabled()
 	{
 		return true;
-	}
-
-	@ConfigSection(
-		name = "Options",
-		description = "Further configure various options",
-		position = 11,
-		closedByDefault = true
-	)
-	String SECTION_OPTIONS = "sectionOptions";
-
-	@ConfigItem(
-		keyName = "pheasantHighlightMode",
-		name = "Pheasant Highlight Mode",
-		description = "Configures how to highlight the pheasant(s) for the Freaky Forester random event.",
-		section = SECTION_OPTIONS,
-		position = 0
-	)
-	default PheasantMode pheasantHighlightMode()
-	{
-		return PheasantMode.SPECIFIC;
 	}
 }

--- a/src/main/java/randomeventhelper/RandomEventHelperConfig.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperConfig.java
@@ -1,10 +1,12 @@
 package randomeventhelper;
 
+import java.util.Set;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import randomeventhelper.randomevents.freakyforester.PheasantMode;
+import randomeventhelper.randomevents.gravedigger.GravediggerHighlightMode;
 
 @ConfigGroup("randomeventhelper")
 public interface RandomEventHelperConfig extends Config
@@ -95,11 +97,27 @@ public interface RandomEventHelperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "gravediggerHighlightMode",
+		name = "Gravedigger Highlight Mode",
+		description = "Configures how to highlight the graves and coffins for the Gravedigger random event.<br>Hold CTRL to select multiple options.",
+		section = SECTION_GRAVEDIGGER,
+		position = 1
+	)
+	default Set<GravediggerHighlightMode> gravediggerHighlightMode()
+	{
+		return Set.of(
+			GravediggerHighlightMode.GRAVESTONE_ICON,
+			GravediggerHighlightMode.HIGHLIGHT_GRAVE,
+			GravediggerHighlightMode.HIGHLIGHT_COFFIN
+		);
+	}
+
+	@ConfigItem(
 		keyName = "gravediggerUseSkillIcons",
 		name = "Use skill icons instead of item icons",
 		description = "Use the associated skill icons instead of item icons for gravestones and coffins in the Gravedigger random event.",
 		section = SECTION_GRAVEDIGGER,
-		position = 1
+		position = 2
 	)
 	default boolean gravediggerUseSkillIcons()
 	{

--- a/src/main/java/randomeventhelper/RandomEventHelperItemOverlay.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperItemOverlay.java
@@ -4,6 +4,7 @@ import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 
@@ -12,13 +13,15 @@ public class RandomEventHelperItemOverlay extends WidgetItemOverlay
 	private final Client client;
 	private final RandomEventHelperPlugin plugin;
 	private final ModelOutlineRenderer modelOutlineRenderer;
+	private final SpriteManager spriteManager;
 
 	@Inject
-	public RandomEventHelperItemOverlay(Client client, RandomEventHelperPlugin plugin, ModelOutlineRenderer modelOutlineRenderer)
+	public RandomEventHelperItemOverlay(Client client, RandomEventHelperPlugin plugin, ModelOutlineRenderer modelOutlineRenderer, SpriteManager spriteManager)
 	{
 		this.client = client;
 		this.plugin = plugin;
 		this.modelOutlineRenderer = modelOutlineRenderer;
+		this.spriteManager = spriteManager;
 		showOnInventory();
 	}
 

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -34,6 +34,7 @@ import randomeventhelper.randomevents.beekeeper.BeekeeperHelper;
 import randomeventhelper.randomevents.drilldemon.DrillDemonHelper;
 import randomeventhelper.randomevents.freakyforester.FreakyForesterHelper;
 import randomeventhelper.randomevents.gravedigger.GravediggerHelper;
+import randomeventhelper.randomevents.gravedigger.GravediggerOverlay;
 import randomeventhelper.randomevents.maze.MazeHelper;
 import randomeventhelper.randomevents.mime.MimeHelper;
 import randomeventhelper.randomevents.pinball.PinballHelper;
@@ -88,6 +89,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private GravediggerHelper gravediggerHelper;
 
 	@Inject
+	private GravediggerOverlay gravediggerOverlay;
+
+	@Inject
 	private MimeHelper mimeHelper;
 
 	@Inject
@@ -129,7 +133,7 @@ public class RandomEventHelperPlugin extends Plugin
 		}
 		if (config.isGravediggerEnabled())
 		{
-			gravediggerHelper.startUp();
+			gravediggerHelper.startUp(gravediggerOverlay);
 		}
 		if (config.isMimeEnabled())
 		{
@@ -236,7 +240,7 @@ public class RandomEventHelperPlugin extends Plugin
 			{
 				if (config.isGravediggerEnabled())
 				{
-					gravediggerHelper.startUp();
+					gravediggerHelper.startUp(gravediggerOverlay);
 				}
 				else
 				{

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/Coffin.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/Coffin.java
@@ -16,17 +16,19 @@ import net.runelite.client.game.SpriteManager;
 @AllArgsConstructor
 public enum Coffin
 {
-	CRAFTING(0, ItemID.MACRO_DIGGER_COFFIN_OBJECT_1, ItemID.POT_EMPTY, SpriteID.Staticons.CRAFTING, new Color(88, 58, 12)),
-	MINING(1, ItemID.MACRO_DIGGER_COFFIN_OBJECT_2, ItemID.BRONZE_PICKAXE, SpriteID.Staticons.MINING, Color.LIGHT_GRAY),
-	COOKING(2, ItemID.MACRO_DIGGER_COFFIN_OBJECT_3, ItemID.CHEFS_HAT, SpriteID.Staticons.COOKING, Color.ORANGE),
-	FARMING(3, ItemID.MACRO_DIGGER_COFFIN_OBJECT_4, ItemID.DIBBER, SpriteID.Staticons2.FARMING, Color.BLUE),
-	WOODCUTTING(4, ItemID.MACRO_DIGGER_COFFIN_OBJECT_5, ItemID.BRONZE_AXE, SpriteID.Staticons.WOODCUTTING, Color.GREEN),
-	EMPTY(5, -1, -1, -1, Color.BLACK); // No item ID for empty coffin
+	CRAFTING(0, ItemID.MACRO_DIGGER_COFFIN_OBJECT_1, ItemID.POT_EMPTY, "Pot", SpriteID.Staticons.CRAFTING, "Craft", new Color(88, 58, 12)),
+	MINING(1, ItemID.MACRO_DIGGER_COFFIN_OBJECT_2, ItemID.BRONZE_PICKAXE, "Pickaxe", SpriteID.Staticons.MINING, "Mine", Color.LIGHT_GRAY),
+	COOKING(2, ItemID.MACRO_DIGGER_COFFIN_OBJECT_3, ItemID.CHEFS_HAT, "Cook", SpriteID.Staticons.COOKING, "Cook", Color.ORANGE),
+	FARMING(3, ItemID.MACRO_DIGGER_COFFIN_OBJECT_4, ItemID.DIBBER, "Seed", SpriteID.Staticons2.FARMING, "Farm", Color.BLUE),
+	WOODCUTTING(4, ItemID.MACRO_DIGGER_COFFIN_OBJECT_5, ItemID.BRONZE_AXE, "Axe", SpriteID.Staticons.WOODCUTTING, "Woodcut", Color.GREEN),
+	EMPTY(5, -1, -1, "", -1, "", Color.BLACK); // No item ID for empty coffin
 
 	private final int varbitValue; // Value for both MACRO_DIGGER_GRAVE and MACRO_DIGGER_COFFIN
 	private final int itemID; // Item ID of the coffin item itself
 	private final int associatedItemID; // An item ID associated with the coffin's contents
+	private final String associatedItemName; // Name of the associated item
 	private final int associatedSkillSpriteID; // Skill sprite ID associated with the coffin's contents
+	private final String associatedSkillName; // Name of the associated skill
 	private final Color color; // A color associated with the coffin and the skill it represents based on its contents
 
 	private static final Map<Integer, Coffin> VARBIT_COFFIN_MAP;

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/Coffin.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/Coffin.java
@@ -8,23 +8,26 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.SpriteID;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 
 @Getter
 @AllArgsConstructor
 public enum Coffin
 {
-	CRAFTING(0, ItemID.MACRO_DIGGER_COFFIN_OBJECT_1, ItemID.POT_EMPTY, new Color(88, 58, 12)),
-	MINING(1, ItemID.MACRO_DIGGER_COFFIN_OBJECT_2, ItemID.BRONZE_PICKAXE, Color.LIGHT_GRAY),
-	COOKING(2, ItemID.MACRO_DIGGER_COFFIN_OBJECT_3, ItemID.CHEFS_HAT, Color.ORANGE),
-	FARMING(3, ItemID.MACRO_DIGGER_COFFIN_OBJECT_4, ItemID.DIBBER, Color.BLUE),
-	WOODCUTTING(4, ItemID.MACRO_DIGGER_COFFIN_OBJECT_5, ItemID.BRONZE_AXE, Color.GREEN),
-	EMPTY(5, -1, -1, Color.BLACK); // No item ID for empty coffin
+	CRAFTING(0, ItemID.MACRO_DIGGER_COFFIN_OBJECT_1, ItemID.POT_EMPTY, SpriteID.Staticons.CRAFTING, new Color(88, 58, 12)),
+	MINING(1, ItemID.MACRO_DIGGER_COFFIN_OBJECT_2, ItemID.BRONZE_PICKAXE, SpriteID.Staticons.MINING, Color.LIGHT_GRAY),
+	COOKING(2, ItemID.MACRO_DIGGER_COFFIN_OBJECT_3, ItemID.CHEFS_HAT, SpriteID.Staticons.COOKING, Color.ORANGE),
+	FARMING(3, ItemID.MACRO_DIGGER_COFFIN_OBJECT_4, ItemID.DIBBER, SpriteID.Staticons2.FARMING, Color.BLUE),
+	WOODCUTTING(4, ItemID.MACRO_DIGGER_COFFIN_OBJECT_5, ItemID.BRONZE_AXE, SpriteID.Staticons.WOODCUTTING, Color.GREEN),
+	EMPTY(5, -1, -1, -1, Color.BLACK); // No item ID for empty coffin
 
 	private final int varbitValue; // Value for both MACRO_DIGGER_GRAVE and MACRO_DIGGER_COFFIN
-	private final int itemID; // Item ID of the coffin item
-	private final int associatedItemID; // An item ID associated with the coffin
-	private final Color color;
+	private final int itemID; // Item ID of the coffin item itself
+	private final int associatedItemID; // An item ID associated with the coffin's contents
+	private final int associatedSkillSpriteID; // Skill sprite ID associated with the coffin's contents
+	private final Color color; // A color associated with the coffin and the skill it represents based on its contents
 
 	private static final Map<Integer, Coffin> VARBIT_COFFIN_MAP;
 	private static final Map<Integer, Coffin> ITEMID_COFFIN_MAP;
@@ -53,5 +56,14 @@ public enum Coffin
 			return null;
 		}
 		return itemManager.getImage(this.associatedItemID);
+	}
+
+	public BufferedImage getSkillIconImage(SpriteManager spriteManager)
+	{
+		if (this.associatedSkillSpriteID == -1)
+		{
+			return null;
+		}
+		return spriteManager.getSprite(this.associatedSkillSpriteID, 0);
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
@@ -33,6 +33,7 @@ import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import randomeventhelper.RandomEventHelperPlugin;
 
@@ -50,9 +51,11 @@ public class GravediggerHelper
 	private ItemManager itemManager;
 
 	@Inject
-	private OverlayManager overlayManager;
+	private SpriteManager spriteManager;
 
 	@Inject
+	private OverlayManager overlayManager;
+
 	private GravediggerOverlay gravediggerOverlay;
 
 	@Inject
@@ -73,11 +76,11 @@ public class GravediggerHelper
 	@Getter
 	private Set<Integer> coffinsInInventory;
 
-
-	public void startUp()
+	public void startUp(GravediggerOverlay gravediggerOverlay)
 	{
+		this.gravediggerOverlay = gravediggerOverlay;
 		this.eventBus.register(this);
-		this.overlayManager.add(gravediggerOverlay);
+		this.overlayManager.add(this.gravediggerOverlay);
 		this.overlayManager.add(gravediggerItemOverlay);
 		this.initiallyEnteredGraveDiggerArea = true;
 		this.graveMap = Maps.newHashMapWithExpectedSize(5);
@@ -90,7 +93,11 @@ public class GravediggerHelper
 	public void shutDown()
 	{
 		this.eventBus.unregister(this);
-		this.overlayManager.remove(gravediggerOverlay);
+		if (this.gravediggerOverlay != null)
+		{
+			this.overlayManager.remove(gravediggerOverlay);
+			this.gravediggerOverlay = null;
+		}
 		this.overlayManager.remove(gravediggerItemOverlay);
 		this.initiallyEnteredGraveDiggerArea = true;
 		this.graveMap = null;

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
@@ -70,6 +70,9 @@ public class GravediggerHelper
 	@Getter
 	private Map<Coffin, BufferedImage> coffinItemImageMap;
 
+	@Getter
+	private Map<Coffin, BufferedImage> coffinSkillImageMap;
+
 	private Multiset<Integer> previousInventory;
 	private Multiset<Integer> currentInventoryItems;
 
@@ -85,6 +88,7 @@ public class GravediggerHelper
 		this.initiallyEnteredGraveDiggerArea = true;
 		this.graveMap = Maps.newHashMapWithExpectedSize(5);
 		this.coffinItemImageMap = Maps.newHashMapWithExpectedSize(5);
+		this.coffinSkillImageMap = Maps.newHashMapWithExpectedSize(5);
 		this.previousInventory = HashMultiset.create();
 		this.currentInventoryItems = HashMultiset.create();
 		this.coffinsInInventory = Sets.newHashSetWithExpectedSize(5);
@@ -102,6 +106,7 @@ public class GravediggerHelper
 		this.initiallyEnteredGraveDiggerArea = true;
 		this.graveMap = null;
 		this.coffinItemImageMap = null;
+		this.coffinSkillImageMap = null;
 		this.previousInventory = null;
 		this.currentInventoryItems = null;
 		this.coffinsInInventory = null;
@@ -164,7 +169,15 @@ public class GravediggerHelper
 			{
 				for (Coffin coffin : Coffin.values())
 				{
-					coffinItemImageMap.put(coffin, coffin.getItemImage(this.itemManager));
+					this.coffinItemImageMap.put(coffin, coffin.getItemImage(this.itemManager));
+				}
+			}
+
+			if (this.coffinSkillImageMap.isEmpty())
+			{
+				for (Coffin coffin : Coffin.values())
+				{
+					this.coffinSkillImageMap.put(coffin, coffin.getSkillIconImage(this.spriteManager));
 				}
 			}
 

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHighlightMode.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHighlightMode.java
@@ -1,0 +1,22 @@
+package randomeventhelper.randomevents.gravedigger;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum GravediggerHighlightMode
+{
+	GRAVESTONE_ICON("Gravestone Icon"), // The icon over the gravestove
+	COFFIN_ICON("Coffin Icon"), // The icon over the coffin in inventory
+	HIGHLIGHT_GRAVE("Highlight Grave"), // Highlight overlay on the grave and gravestone
+	HIGHLIGHT_COFFIN("Highlight Coffin"), // Highlight overlay on the coffin in inventory
+	TEXT_GRAVE("Grave Text"), // Text overlay on the grave
+	TEXT_COFFIN("Coffin Text"); // Text overlay on the coffin in inventory
+
+	private final String displayName;
+
+	@Override
+	public String toString()
+	{
+		return this.displayName;
+	}
+}

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerItemOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerItemOverlay.java
@@ -3,39 +3,92 @@ package randomeventhelper.randomevents.gravedigger;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Point;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
+import net.runelite.client.util.ImageUtil;
+import randomeventhelper.RandomEventHelperConfig;
 
 @Slf4j
 @Singleton
 public class GravediggerItemOverlay extends WidgetItemOverlay
 {
 	private final Client client;
-	private final GravediggerHelper plugin;
+	private final RandomEventHelperConfig config;
+	private final GravediggerHelper gravediggerHelper;
+
+	private final double SCALE_FACTOR = 0.8;
 
 	@Inject
-	public GravediggerItemOverlay(Client client, GravediggerHelper plugin)
+	public GravediggerItemOverlay(Client client, RandomEventHelperConfig config, GravediggerHelper gravediggerHelper)
 	{
 		this.client = client;
-		this.plugin = plugin;
+		this.config = config;
+		this.gravediggerHelper = gravediggerHelper;
 		showOnInventory();
 	}
 
 	@Override
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
 	{
-		if (plugin.getCoffinsInInventory() != null && !plugin.getCoffinsInInventory().isEmpty() && plugin.getCoffinsInInventory().contains(itemId))
+		if (gravediggerHelper.getCoffinsInInventory() != null && !gravediggerHelper.getCoffinsInInventory().isEmpty() && gravediggerHelper.getCoffinsInInventory().contains(itemId))
 		{
 			Coffin coffin = Coffin.getCoffinFromItemID(itemId);
-			Color requiredCoffinColor = coffin != null ? coffin.getColor() : Color.BLACK;
-			Color requiredCoffinTransparentColor = coffin != null ? this.getTransparentColor(coffin.getColor(), 50) : Color.BLACK;
-			OverlayUtil.renderPolygon(graphics, widgetItem.getCanvasBounds(), requiredCoffinColor, requiredCoffinTransparentColor, new BasicStroke(2));
+			if (config.gravediggerHighlightMode().contains(GravediggerHighlightMode.HIGHLIGHT_COFFIN))
+			{
+				renderHighlightCoffinInInventory(graphics, widgetItem, coffin);
+			}
+
+			if (config.gravediggerHighlightMode().contains(GravediggerHighlightMode.COFFIN_ICON))
+			{
+				renderCoffinIconInInventory(graphics, widgetItem, coffin);
+			}
+
+			if (config.gravediggerHighlightMode().contains(GravediggerHighlightMode.TEXT_COFFIN))
+			{
+				renderCoffinTextInInventory(graphics, widgetItem, coffin);
+			}
 		}
+	}
+
+	private void renderCoffinTextInInventory(Graphics2D graphics, WidgetItem widgetItem, Coffin coffin)
+	{
+		Point textPoint = new Point(widgetItem.getCanvasBounds().x - 1, (widgetItem.getCanvasBounds().y - 1) + widgetItem.getCanvasBounds().height);
+		String coffinText = this.config.gravediggerUseSkillIcons() ? coffin.getAssociatedSkillName() : coffin.getAssociatedItemName();
+		OverlayUtil.renderTextLocation(graphics, textPoint, coffinText, Color.WHITE);
+	}
+
+	private void renderCoffinIconInInventory(Graphics2D graphics, WidgetItem widgetItem, Coffin coffin)
+	{
+		BufferedImage coffinImage = this.config.gravediggerUseSkillIcons() ? this.gravediggerHelper.getCoffinSkillImageMap().get(coffin) : this.gravediggerHelper.getCoffinItemImageMap().get(coffin);
+		if (coffinImage == null)
+		{
+			return;
+		}
+
+		BufferedImage rescaledCoffinImage = ImageUtil.resizeImage(coffinImage, (int) (coffinImage.getWidth() * this.SCALE_FACTOR), (int) (coffinImage.getHeight() * this.SCALE_FACTOR));
+		Point point = widgetItem.getCanvasLocation();
+		// Move the point to be the bottom right of the item
+		int dx = (int) (point.getX() + widgetItem.getCanvasBounds().getWidth() - rescaledCoffinImage.getWidth());
+		int dy = (int) (point.getY() + 1);
+		// Move the point to be at the bottom right, but making sure the x and y are capped within the widget bounds using Math.min
+		// dx = Math.min(dx, (int) (widgetItem.getCanvasBounds().getX() + widgetItem.getCanvasBounds().getWidth() - rescaledCoffinImage.getWidth()));
+		// dy = Math.min(dy, (int) (widgetItem.getCanvasBounds().getY() + widgetItem.getCanvasBounds().getHeight() - rescaledCoffinImage.getHeight()));
+		point = new Point(dx, dy);
+		OverlayUtil.renderImageLocation(graphics, point, rescaledCoffinImage);
+	}
+
+	private void renderHighlightCoffinInInventory(Graphics2D graphics, WidgetItem widgetItem, Coffin coffin)
+	{
+		Color requiredCoffinColor = coffin != null ? coffin.getColor() : Color.BLACK;
+		Color requiredCoffinTransparentColor = coffin != null ? this.getTransparentColor(coffin.getColor(), 50) : Color.BLACK;
+		OverlayUtil.renderPolygon(graphics, widgetItem.getCanvasBounds(), requiredCoffinColor, requiredCoffinTransparentColor, new BasicStroke(2));
 	}
 
 	private Color getTransparentColor(Color color, int alpha)

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
@@ -75,57 +75,84 @@ public class GravediggerOverlay extends Overlay
 					{
 						continue;
 					}
-					if (grave.getGraveStone() != null)
-					{
-						Point location = grave.getGraveStone().getCanvasLocation();
-						LocalPoint localPoint = grave.getGraveStone().getLocalLocation();
-						if (location != null)
-						{
-							OverlayUtil.renderImageLocation(client, graphics2D, localPoint, coffinImage, 50);
-						}
-						// Also outline the gravestone
-						Shape graveStoneHull = grave.getGraveStone().getConvexHull();
-						if (graveStoneHull != null)
-						{
-							OverlayUtil.renderPolygon(graphics2D, graveStoneHull, requiredCoffinColor);
-						}
-					}
+
+					renderGravestoneIcon(graphics2D, grave, coffinImage, requiredCoffinColor);
+					renderHighlightGravestone(graphics2D, grave, coffinImage, requiredCoffinColor);
+
 					// If the grave is empty, then highlight it according to
 					if (placedCoffin == Coffin.EMPTY)
 					{
-						Shape emptyGraveHull = grave.getEmptyGrave().getConvexHull();
-						if (emptyGraveHull != null)
-						{
-							OverlayUtil.renderPolygon(graphics2D, emptyGraveHull, requiredCoffinColor, requiredCoffinTransparentColor, new BasicStroke(2));
-						}
+						renderHighlightEmptyGrave(graphics2D, grave, requiredCoffinColor, requiredCoffinTransparentColor, 2);
 					}
 					else
 					{
-						Shape filledGraveHull = grave.getFilledGrave().getConvexHull();
-						if (filledGraveHull != null)
-						{
-							OverlayUtil.renderPolygon(graphics2D, filledGraveHull, placedCoffinColor, placedCoffinTransparentColor, new BasicStroke(2));
-							Point centeredSpritePoint = Perspective.getCanvasImageLocation(client, grave.getFilledGrave().getLocalLocation(), checkBufferedImage, 0);
-							if (placedCoffin != requiredCoffin)
-							{
-								if (centeredSpritePoint != null)
-								{
-									OverlayUtil.renderImageLocation(graphics2D, centeredSpritePoint, crossBufferedImage);
-								}
-							}
-							else
-							{
-								if (centeredSpritePoint != null)
-								{
-									OverlayUtil.renderImageLocation(graphics2D, centeredSpritePoint, checkBufferedImage);
-								}
-							}
-						}
+						renderHighlightFilledGrave(graphics2D, grave, placedCoffinColor, placedCoffinTransparentColor, placedCoffin, requiredCoffin, 2);
 					}
 				}
 			}
 		}
 		return null;
+	}
+
+	private void renderGravestoneIcon(Graphics2D graphics2D, Grave grave, BufferedImage coffinImage, Color requiredCoffinColor)
+	{
+		if (grave.getGraveStone() != null)
+		{
+			Point location = grave.getGraveStone().getCanvasLocation();
+			LocalPoint localPoint = grave.getGraveStone().getLocalLocation();
+			if (location != null)
+			{
+				OverlayUtil.renderImageLocation(client, graphics2D, localPoint, coffinImage, 50);
+			}
+		}
+	}
+
+	private void renderHighlightGravestone(Graphics2D graphics2D, Grave grave, BufferedImage coffinImage, Color requiredCoffinColor)
+	{
+		if (grave.getGraveStone() != null)
+		{
+			Shape graveStoneHull = grave.getGraveStone().getConvexHull();
+			if (graveStoneHull != null)
+			{
+				OverlayUtil.renderPolygon(graphics2D, graveStoneHull, requiredCoffinColor);
+			}
+		}
+	}
+
+	private void renderHighlightEmptyGrave(Graphics2D graphics2D, Grave grave, Color requiredCoffinColor, Color requiredCoffinTransparentColor, int strokeWidth)
+	{
+		if (grave.getEmptyGrave() != null)
+		{
+			Shape emptyGraveHull = grave.getEmptyGrave().getConvexHull();
+			if (emptyGraveHull != null)
+			{
+				OverlayUtil.renderPolygon(graphics2D, emptyGraveHull, requiredCoffinColor, requiredCoffinTransparentColor, new BasicStroke(strokeWidth));
+			}
+		}
+	}
+
+	private void renderHighlightFilledGrave(Graphics2D graphics2D, Grave grave, Color placedCoffinColor, Color placedCoffinTransparentColor, Coffin placedCoffin, Coffin requiredCoffin, int strokeWidth)
+	{
+		if (grave.getFilledGrave() != null)
+		{
+			Shape filledGraveHull = grave.getFilledGrave().getConvexHull();
+			if (filledGraveHull != null)
+			{
+				OverlayUtil.renderPolygon(graphics2D, filledGraveHull, placedCoffinColor, placedCoffinTransparentColor, new BasicStroke(strokeWidth));
+				Point centeredSpritePoint = Perspective.getCanvasImageLocation(client, grave.getFilledGrave().getLocalLocation(), checkBufferedImage, 0);
+				if (centeredSpritePoint != null)
+				{
+					if (placedCoffin != requiredCoffin)
+					{
+						OverlayUtil.renderImageLocation(graphics2D, centeredSpritePoint, crossBufferedImage);
+					}
+					else
+					{
+						OverlayUtil.renderImageLocation(graphics2D, centeredSpritePoint, checkBufferedImage);
+					}
+				}
+			}
+		}
 	}
 
 	private Color getTransparentColor(Color color, int alpha)

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
@@ -20,23 +20,27 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import randomeventhelper.RandomEventHelperConfig;
 
 @Slf4j
 @Singleton
 public class GravediggerOverlay extends Overlay
 {
 	private final Client client;
+	private final RandomEventHelperConfig config;
+	private final GravediggerHelper gravediggerHelper;
 	private final SpriteManager spriteManager;
 	private final GravediggerHelper plugin;
 	private BufferedImage checkBufferedImage;
 	private BufferedImage crossBufferedImage;
 
 	@Inject
-	public GravediggerOverlay(Client client, GravediggerHelper plugin, SpriteManager spriteManager)
+	public GravediggerOverlay(Client client, RandomEventHelperConfig config, GravediggerHelper gravediggerHelper, SpriteManager spriteManager)
 	{
 		this.client = client;
+		this.config = config;
 		this.spriteManager = spriteManager;
-		this.plugin = plugin;
+		this.gravediggerHelper = gravediggerHelper;
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
@@ -44,7 +48,7 @@ public class GravediggerOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics2D)
 	{
-		if (plugin.getGraveMap() != null && !plugin.getGraveMap().isEmpty())
+		if (this.gravediggerHelper.getGraveMap() != null && !this.gravediggerHelper.getGraveMap().isEmpty())
 		{
 			if (checkBufferedImage == null)
 			{
@@ -54,13 +58,13 @@ public class GravediggerOverlay extends Overlay
 			{
 				this.crossBufferedImage = this.spriteManager.getSprite(SpriteID.OptionsRadioButtons.CROSS_RED, 0);
 			}
-			for (Map.Entry<GraveNumber, Grave> graveEntry : plugin.getGraveMap().entrySet())
+			for (Map.Entry<GraveNumber, Grave> graveEntry : this.gravediggerHelper.getGraveMap().entrySet())
 			{
 				GraveNumber graveNumber = graveEntry.getKey();
 				Grave grave = graveEntry.getValue();
 				if (grave != null)
 				{
-					BufferedImage coffinImage = plugin.getCoffinItemImageMap().get(grave.getRequiredCoffin());
+					BufferedImage coffinImage = this.gravediggerHelper.getCoffinItemImageMap().get(grave.getRequiredCoffin());
 					Coffin requiredCoffin = grave.getRequiredCoffin();
 					Coffin placedCoffin = grave.getPlacedCoffin();
 					if (requiredCoffin == null || placedCoffin == null)

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
@@ -30,7 +30,6 @@ public class GravediggerOverlay extends Overlay
 	private final RandomEventHelperConfig config;
 	private final GravediggerHelper gravediggerHelper;
 	private final SpriteManager spriteManager;
-	private final GravediggerHelper plugin;
 	private BufferedImage checkBufferedImage;
 	private BufferedImage crossBufferedImage;
 
@@ -64,7 +63,7 @@ public class GravediggerOverlay extends Overlay
 				Grave grave = graveEntry.getValue();
 				if (grave != null)
 				{
-					BufferedImage coffinImage = this.gravediggerHelper.getCoffinItemImageMap().get(grave.getRequiredCoffin());
+					BufferedImage coffinImage = this.config.gravediggerUseSkillIcons() ? this.gravediggerHelper.getCoffinSkillImageMap().get(grave.getRequiredCoffin()) : this.gravediggerHelper.getCoffinItemImageMap().get(grave.getRequiredCoffin());
 					Coffin requiredCoffin = grave.getRequiredCoffin();
 					Coffin placedCoffin = grave.getPlacedCoffin();
 					if (requiredCoffin == null || placedCoffin == null)


### PR DESCRIPTION
WIP for more highlight modes support. Already have the basis and currently working on refactoring before implementing

- [x] Add support for starting the plugin already in the instance
	- Tested and working
- [x] Add configurable highlight options (Gravestone Icon, Coffin Icon, Highlight Grave, Highlight Coffin, Gravestone Text, Coffin Text)
	- Basic implementation of options and config changes
- [x] Change the item icons into skill icons instead
	- Implemented but haven't tested

### feat(gravedigger): Add support for starting in event (#28)

- Added proper support for handling initial runs when (re)starting the plugin when already inside the random event