### PR TITLE
[Surprise Exam] Fix matching puzzles hints "thirsty" and "drink"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.5.11'
+version = '2.5.12'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -52,7 +52,7 @@ public class OSRSItemRelationshipSystem
 		Map.entry("grow", Set.of("farming", "plants", "crops", "agriculture")),
 		Map.entry("mine", Set.of("mining", "pickaxe", "ore", "rocks")),
 		Map.entry("protection", Set.of("armor", "helmet", "shield", "defense")),
-		Map.entry("drink", Set.of("alcohol", "beverage", "beer", "cocktail")),
+		Map.entry("drink", Set.of("alcohol", "beverage", "beer", "cocktail", "thirsty")),
 		Map.entry("light", Set.of("fire", "candle", "lantern", "tinder", "illuminate")),
 		Map.entry("jewel", Set.of("jewelry", "gem", "necklace", "ring", "crafting", "amulet")),
 		Map.entry("pirate", Set.of("sea", "yarr", "piracy", "treasure", "chest", "loot", "gold", "crime")),
@@ -67,7 +67,7 @@ public class OSRSItemRelationshipSystem
 		"armor", Set.of("protection", "gear", "equipment", "defense", "guard"),
 		"magic", Set.of("spell", "enchantment", "sorcery", "wizardry", "mystical"),
 		"pirate", Set.of("buccaneer", "seafarer", "mariner", "sailor", "nautical"),
-		"drink", Set.of("beverage", "liquid", "fluid", "potion", "brew"),
+		"drink", Set.of("beverage", "liquid", "fluid", "potion", "brew", "sip"),
 		"tool", Set.of("equipment", "implement", "instrument", "utility", "gear"),
 		"bow", Set.of("archery", "ranged", "range", "arrow", "archer", "crossbow")
 	);
@@ -272,6 +272,12 @@ public class OSRSItemRelationshipSystem
 		map.put(RelationshipType.ALCOHOLIC_DRINKS, Set.of(
 			RandomEventItem.BEER, RandomEventItem.GIN_OR_RUM, RandomEventItem.COCKTAIL_1,
 			RandomEventItem.COCKTAIL_2
+		));
+
+		map.put(RelationshipType.DRINKS, Set.of(
+			RandomEventItem.BEER, RandomEventItem.GIN_OR_RUM, RandomEventItem.COCKTAIL_1,
+			RandomEventItem.COCKTAIL_2, RandomEventItem.CUP_OF_TEA, RandomEventItem.BOTTLE, RandomEventItem.JUG,
+			RandomEventItem.POTION
 		));
 
 		// Functional groupings

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -44,7 +44,8 @@ public enum RelationshipType
 	FISH("fish, raw, uncooked, sea, food, sea food, seafood, fishing, water"),
 	FRUITS("fruits, berries, fresh, healthy, vitamins, nature"),
 	BAKING_FOOD("cooked, food, meals, prepared, baked, ready"),
-	ALCOHOLIC_DRINKS("alcohol, drinks, beer, spirits, intoxicating, beverages"),
+	ALCOHOLIC_DRINKS("alcohol, drinks, beer, spirits, intoxicating, beverages, thirsty"),
+	DRINKS("drink, beverage, refreshing, hydrate, quench, thirsty, liquid, sip"),
 
 	// Functional groupings
 	COMBAT_CONSUMABLES("combat, consumable, potion, bones, prayer, aid"),

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -30,6 +30,46 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle2ActualItems = relationshipSystem.findItemsByHint(puzzle2.getHint(), puzzle2.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle2ActualItems).containsExactlyInAnyOrderElementsOf(puzzle2.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle3 = new RelationshipSystemTestMatchingData(
+			"I shall unmask this pattern!",
+			"[ONION (41226), SCIMITAR (41192), LONGBOW (41198), HIGHWAYMAN_MASK (41195), MIME_MASK (41191), BATTLE_AXE (41176), KITCHEN_KNIFE (41201), SPADE (41155), BAR (41153), TROUT_COD_PIKE_SALMON_3 (41163), JUG (41225), FROG_MASK (27101), POTION (41149), THREAD (41218), CANDLE_LANTERN (41229)]",
+			List.of(RandomEventItem.MIME_MASK, RandomEventItem.FROG_MASK, RandomEventItem.HIGHWAYMAN_MASK)
+		);
+		List<RandomEventItem> puzzle3ActualItems = relationshipSystem.findItemsByHint(puzzle3.getHint(), puzzle3.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle3ActualItems).containsExactlyInAnyOrderElementsOf(puzzle3.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle4 = new RelationshipSystemTestMatchingData(
+			"All this work is making me thirsty.",
+			"[SHORT_BOW (41171), LONGSWORD (41150), COCKTAIL_1 (27097), HARPOON (41158), CUP_OF_TEA (41162), BOOK (41181), TROUT_COD_PIKE_SALMON_3 (41163), PLANT_POT (41208), LOGS (41232), TINDERBOX (41154), GEM_WITH_CROSS (41151), SECATEURS (41197), TROUT_COD_PIKE_SALMON_4 (41217), ORE (41170), BEER (41152)]",
+			List.of(RandomEventItem.COCKTAIL_1, RandomEventItem.CUP_OF_TEA, RandomEventItem.BEER)
+		);
+		List<RandomEventItem> puzzle4ActualItems = relationshipSystem.findItemsByHint(puzzle4.getHint(), puzzle4.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle4ActualItems).containsExactlyInAnyOrderElementsOf(puzzle4.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle5 = new RelationshipSystemTestMatchingData(
+			"The pen may be mightier than the sword, but against a dragon? I'll take a melee weapon.",
+			"[BOTTLE (41175), BAR (41153), INSULATED_BOOTS (27104), SCIMITAR (41192), TROUT_COD_PIKE_SALMON_3 (41163), BATTLE_AXE (41176), CROSSBOW (41146), BEER (41152), NEEDLE (41199), RAKE (41212), RUNE_OR_ESSENCE (41182), BONES (2674), POT (41223), LONGSWORD (41150), LOGS (41232)]",
+			List.of(RandomEventItem.SCIMITAR, RandomEventItem.BATTLE_AXE, RandomEventItem.LONGSWORD)
+		);
+		List<RandomEventItem> puzzle5ActualItems = relationshipSystem.findItemsByHint(puzzle5.getHint(), puzzle5.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle5ActualItems).containsExactlyInAnyOrderElementsOf(puzzle5.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle6 = new RelationshipSystemTestMatchingData(
+			"This pattern is as sharp as an arrow.",
+			"[CROSSBOW (41146), SCIMITAR (41192), BATTLE_AXE (41176), LONGBOW (41198), SHEARS (41227), TINDERBOX (41154), JUG (41225), FROG_MASK (27101), COCKTAIL_1 (27097), CAKE (41202), BOTTLE (41175), GARDENING_TROWEL (41210), LONGSWORD (41150), PIRATE_HAT (41187), ARROWS (41177)]",
+			List.of(RandomEventItem.CROSSBOW, RandomEventItem.LONGBOW, RandomEventItem.ARROWS)
+		);
+		List<RandomEventItem> puzzle6ActualItems = relationshipSystem.findItemsByHint(puzzle6.getHint(), puzzle6.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle6ActualItems).containsExactlyInAnyOrderElementsOf(puzzle6.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle7 = new RelationshipSystemTestMatchingData(
+			"Fancy a drink?",
+			"[CUP_OF_TEA (41162), SECATEURS (41197), ORE (41170), TROUT_COD_PIKE_SALMON_4 (41217), BEER (41152), PLANT_POT (41208), TINDERBOX (41154), LOGS (41232), BOOK (41181), LONGSWORD (41150), HARPOON (41158), SHORT_BOW (41171), GEM_WITH_CROSS (41151), TROUT_COD_PIKE_SALMON_3 (41163), COCKTAIL_1 (27097)]",
+			List.of(RandomEventItem.CUP_OF_TEA, RandomEventItem.BEER, RandomEventItem.COCKTAIL_1)
+		);
+		List<RandomEventItem> puzzle7ActualItems = relationshipSystem.findItemsByHint(puzzle7.getHint(), puzzle7.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle7ActualItems).containsExactlyInAnyOrderElementsOf(puzzle7.getExpectedMatchingItems());
 	}
 
 	@Test
@@ -51,6 +91,46 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle2ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle2.getInitialSequenceItems(), puzzle2.getItemChoices());
 		Assertions.assertThat(puzzle2ActualNextMissingItem).isEqualTo(puzzle2.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle3 = new RelationshipSystemTestNextMissingItemData(
+			"[NECKLACE (41216), TIARA (41148), HOLY_SYMBOL (41159)]",
+			"[HAMMER (41183), RING (27091), HERRING_OR_MACKEREL (41193)]",
+			RandomEventItem.RING
+		);
+		RandomEventItem puzzle3ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle3.getInitialSequenceItems(), puzzle3.getItemChoices());
+		Assertions.assertThat(puzzle3ActualNextMissingItem).isEqualTo(puzzle3.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle4 = new RelationshipSystemTestNextMissingItemData(
+			"[GARDENING_TROWEL (41210), WATERING_CAN (41213), SPADE (41155)]",
+			"[CAKE (41202), WATER_RUNE (41231), RAKE (41212), FIRE_RUNE (41215)]",
+			RandomEventItem.RAKE
+		);
+		RandomEventItem puzzle4ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle4.getInitialSequenceItems(), puzzle4.getItemChoices());
+		Assertions.assertThat(puzzle4ActualNextMissingItem).isEqualTo(puzzle4.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle5 = new RelationshipSystemTestNextMissingItemData(
+			"[CHEFS_HAT (41203), APRON (41190), CAKE (41202)]",
+			"[RAKE (41212), BREAD (41172), BAR (41153), ORE (41170)]",
+			RandomEventItem.BREAD
+		);
+		RandomEventItem puzzle5ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle5.getInitialSequenceItems(), puzzle5.getItemChoices());
+		Assertions.assertThat(puzzle5ActualNextMissingItem).isEqualTo(puzzle5.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle6 = new RelationshipSystemTestNextMissingItemData(
+			"[LONGBOW (41198), ARROWS (41177), CROSSBOW (41146)]",
+			"[TROUT_COD_PIKE_SALMON_1 (41204), FIRE_RUNE (41215), SHORT_BOW (41171), LONGSWORD (41150)]",
+			RandomEventItem.SHORT_BOW
+		);
+		RandomEventItem puzzle6ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle6.getInitialSequenceItems(), puzzle6.getItemChoices());
+		Assertions.assertThat(puzzle6ActualNextMissingItem).isEqualTo(puzzle6.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle7 = new RelationshipSystemTestNextMissingItemData(
+			"[BREAD (41172), CAKE (41202), PIE (41205)]",
+			"[LEATHER_BOOTS (41220), WATER_RUNE (41231), PIZZA (41185), ARROWS (41177)]",
+			RandomEventItem.PIZZA
+		);
+		RandomEventItem puzzle7ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle7.getInitialSequenceItems(), puzzle7.getItemChoices());
+		Assertions.assertThat(puzzle7ActualNextMissingItem).isEqualTo(puzzle7.getExpectedNextMissingItem());
 	}
 
 	@Data


### PR DESCRIPTION
### test(surpriseexam): Add more tests for matching and missing item puzzles

- Add more unit tests for matching and missing item puzzles in the Surprise Exam random event
    - Thanks to @rmobis for also contributing data

### fix(surpriseexam): Fix matching puzzles hints like "thirsty" and "drink"

- Add new RelationshipType DRINKS for "thirsty" puzzle and also add "thirsty" to ALCOHOLIC_DRINKS
    - Thanks to @rmobis for pointing out the incorrect "All this work is making me thirsty." matching puzzle
- Update CONTEXT_CLUES and SYNONYMS within OSRSItemRelationshipSystem
- Add new DRINKS relationship type within OSRSItemRelationshipSystem

### chore: Update plugin to v2.5.12

- Added more Surprise Exam random event test cases
- Fixed Surprise Exam event random event incorrect matching puzzles with hints "All this work is making me thirsty." and "Fancy a drink?"