### PR TITLE
[Surprise Exam] Fix incorrect solutions and early returning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.6.0'
+version = '2.6.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -325,30 +325,6 @@ public class OSRSItemRelationshipSystem
 			throw new IllegalArgumentException("Expected exactly 3 known items");
 		}
 
-		// Try each candidate and see which one creates the best relationship
-		for (RandomEventItem candidate : candidates)
-		{
-			List<RandomEventItem> testGroup = new ArrayList<>(knownItems);
-			testGroup.add(candidate);
-
-			// Check if this combination matches any relationship
-			for (Map.Entry<RelationshipType, Set<RandomEventItem>> entry : relationships.entrySet())
-			{
-				Set<RandomEventItem> relationshipItems = entry.getValue();
-
-				// Count how many items from our test group are in this relationship
-				long matches = testGroup.stream()
-					.filter(relationshipItems::contains)
-					.count();
-
-				// If all 4 items are in the relationship, this is likely the answer
-				if (matches == 4)
-				{
-					return candidate;
-				}
-			}
-		}
-
 		// If no perfect match, try partial matching
 		return findMissingItemByPartialMatch(knownItems, candidates);
 	}

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -163,6 +163,30 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle8ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle8.getInitialSequenceItems(), puzzle8.getItemChoices());
 		Assertions.assertThat(puzzle8ActualNextMissingItem).isEqualTo(puzzle8.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle9 = new RelationshipSystemTestNextMissingItemData(
+			"[CUP_OF_TEA (41162), COCKTAIL_2 (28421), GIN_OR_RUM (41219)]",
+			"[LEDERHOSEN_HAT (41164), PIE (41205), BEER (41152), SHORT_BOW (41171)]",
+			RandomEventItem.BEER
+		);
+		RandomEventItem puzzle9ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle9.getInitialSequenceItems(), puzzle9.getItemChoices());
+		Assertions.assertThat(puzzle9ActualNextMissingItem).isEqualTo(puzzle9.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle10 = new RelationshipSystemTestNextMissingItemData(
+			"[KITESHIELD (41200), WOODEN_SHIELD (41221), SQUARE_SHIELD_1 (41188)]",
+			"[SQUARE_SHIELD_2 (41169), COCKTAIL_SHAKER (27096), ORE (41170), CAKE (41202)]",
+			RandomEventItem.SQUARE_SHIELD_2
+		);
+		RandomEventItem puzzle10ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle10.getInitialSequenceItems(), puzzle10.getItemChoices());
+		Assertions.assertThat(puzzle10ActualNextMissingItem).isEqualTo(puzzle10.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle11 = new RelationshipSystemTestNextMissingItemData(
+			"[TINDERBOX (41154), LOGS (41232), CANDLE_ON_STAND (27102)]",
+			"[CANDLE_LANTERN (41229), PICKAXE (41194), PINEAPPLE (41214), ARROWS (41177)]",
+			RandomEventItem.CANDLE_LANTERN
+		);
+		RandomEventItem puzzle11ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle11.getInitialSequenceItems(), puzzle11.getItemChoices());
+		Assertions.assertThat(puzzle11ActualNextMissingItem).isEqualTo(puzzle11.getExpectedNextMissingItem());
 	}
 
 	@Data

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -131,6 +131,15 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle7ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle7.getInitialSequenceItems(), puzzle7.getItemChoices());
 		Assertions.assertThat(puzzle7ActualNextMissingItem).isEqualTo(puzzle7.getExpectedNextMissingItem());
+
+		// LONGBOW (41198), ARROWS (41177), CROSSBOW (41146) -> SHORT_BOW (41171)
+		RelationshipSystemTestNextMissingItemData puzzle8 = new RelationshipSystemTestNextMissingItemData(
+			"[LONGBOW (41198), ARROWS (41177), CROSSBOW (41146)]",
+			"[LONGSWORD (41150), FIRE_RUNE (41215), SHORT_BOW (41171), TROUT_COD_PIKE_SALMON_1 (41204)]",
+			RandomEventItem.SHORT_BOW
+		);
+		RandomEventItem puzzle8ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle8.getInitialSequenceItems(), puzzle8.getItemChoices());
+		Assertions.assertThat(puzzle8ActualNextMissingItem).isEqualTo(puzzle8.getExpectedNextMissingItem());
 	}
 
 	@Data

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -70,6 +70,30 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle7ActualItems = relationshipSystem.findItemsByHint(puzzle7.getHint(), puzzle7.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle7ActualItems).containsExactlyInAnyOrderElementsOf(puzzle7.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle8 = new RelationshipSystemTestMatchingData(
+			"Tools for warriors who hate ranging or magic.",
+			"[CROSSBOW (41146), LOGS (41232), RAKE (41212), INSULATED_BOOTS (27104), BONES (2674), BAR (41153), BATTLE_AXE (41176), NEEDLE (41199), SCIMITAR (41192), BEER (41152), RUNE_OR_ESSENCE (41182), BOTTLE (41175), LONGSWORD (41150), TROUT_COD_PIKE_SALMON_3 (41163), POT (41223)]",
+			List.of(RandomEventItem.BATTLE_AXE, RandomEventItem.SCIMITAR, RandomEventItem.LONGSWORD)
+		);
+		List<RandomEventItem> puzzle8ActualItems = relationshipSystem.findItemsByHint(puzzle8.getHint(), puzzle8.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle8ActualItems).containsExactlyInAnyOrderElementsOf(puzzle8.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle9 = new RelationshipSystemTestMatchingData(
+			"Tools for fighters who hate melee and magic.",
+			"[SCIMITAR (41192), LONGBOW (41198), BOTTLE (41175), SHEARS (41227), PIRATE_HAT (41187), ARROWS (41177), CROSSBOW (41146), LONGSWORD (41150), CAKE (41202), GARDENING_TROWEL (41210), JUG (41225), BATTLE_AXE (41176), TINDERBOX (41154), FROG_MASK (27101), COCKTAIL_1 (27097)]",
+			List.of(RandomEventItem.LONGBOW, RandomEventItem.ARROWS, RandomEventItem.CROSSBOW)
+		);
+		List<RandomEventItem> puzzle9ActualItems = relationshipSystem.findItemsByHint(puzzle9.getHint(), puzzle9.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle9ActualItems).containsExactlyInAnyOrderElementsOf(puzzle9.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle10 = new RelationshipSystemTestMatchingData(
+			"Abracadabra! Hocus pocus!",
+			"[FIRE_RUNE (41215), CUP_OF_TEA (41162), BOTTLE (41175), WATER_RUNE (41231), BATTLE_AXE (41176), INSULATED_BOOTS (27104), PIRATE_HAT (41187), TROUT_COD_PIKE_SALMON_3 (41163), MED_HELM (41189), TINDERBOX (41154), PIRATE_HOOK (41228), NEEDLE (41199), STAFF (41174), EYE_PATCH (41165), GARDENING_TROWEL (41210)]",
+			List.of(RandomEventItem.FIRE_RUNE, RandomEventItem.WATER_RUNE, RandomEventItem.STAFF)
+		);
+		List<RandomEventItem> puzzle10ActualItems = relationshipSystem.findItemsByHint(puzzle10.getHint(), puzzle10.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle10ActualItems).containsExactlyInAnyOrderElementsOf(puzzle10.getExpectedMatchingItems());
 	}
 
 	@Test
@@ -132,7 +156,6 @@ public class RelationshipSystemTest
 		RandomEventItem puzzle7ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle7.getInitialSequenceItems(), puzzle7.getItemChoices());
 		Assertions.assertThat(puzzle7ActualNextMissingItem).isEqualTo(puzzle7.getExpectedNextMissingItem());
 
-		// LONGBOW (41198), ARROWS (41177), CROSSBOW (41146) -> SHORT_BOW (41171)
 		RelationshipSystemTestNextMissingItemData puzzle8 = new RelationshipSystemTestNextMissingItemData(
 			"[LONGBOW (41198), ARROWS (41177), CROSSBOW (41146)]",
 			"[LONGSWORD (41150), FIRE_RUNE (41215), SHORT_BOW (41171), TROUT_COD_PIKE_SALMON_1 (41204)]",


### PR DESCRIPTION
### fix(surpriseexam): Fixed next missing item solver from early return

- Removed the code that calculates how many matches are in a relation and returns early if it's 4
	- This fixed the issue(s) with broader relationships early returning despite a more specific one was the answer
- Added test case which was broken prior to this commit changes thanks to @rmobis

Example: Initial items were ranged and answer set [longsword, bow] -> they are both in COMBAT_ECOSYSTEM so it would early return matching the first item (longsword) instead of checking the other items too which would be the shortbow belonging to the answer relationship - RANGED_WEAPONS (See https://github.com/Infinitay/Random-Event-Helper/issues/33#issuecomment-3615298179 for the particular problem)
