### PR TITLE
[Maze] Better handle initial starts and ignore other VarbitChanged

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.6.1'
+version = '2.6.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
@@ -110,6 +110,12 @@ public class DrillDemonHelper
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
+		// For some reason, when the player is within the maze random event, the varbits for the drill demon event fire/are modified
+		if (this.isInMazeLocalInstance())
+		{
+			return;
+		}
+
 		switch (varbitChanged.getVarbitId())
 		{
 			case VarbitID.MACRO_DRILLDEMON_POST_1:
@@ -205,5 +211,10 @@ public class DrillDemonHelper
 	private boolean isInDrillDemonLocalInstance()
 	{
 		return RandomEventHelperPlugin.getRegionIDFromCurrentLocalPointInstanced(client) == 12619;
+	}
+
+	private boolean isInMazeLocalInstance()
+	{
+		return RandomEventHelperPlugin.getRegionIDFromCurrentLocalPointInstanced(client) == 11591;
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
@@ -18,6 +18,7 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperPlugin;
 
 @Slf4j
 @Singleton
@@ -69,6 +70,12 @@ public class PirateHelper
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
+		// For some reason, when the player is within the maze random event, the varbits for the pirate chest event fire/are modified
+		if (this.isInMazeLocalInstance())
+		{
+			return;
+		}
+
 		switch (varbitChanged.getVarbitId())
 		{
 			case VarbitID.PIRATE_COMBILOCK_LEFT:
@@ -203,5 +210,10 @@ public class PirateHelper
 		{
 			this.widgetMap.put(ChestLockSlot.RIGHT.getSubtractWidgetID(), rightSubtractWidget);
 		}
+	}
+
+	private boolean isInMazeLocalInstance()
+	{
+		return RandomEventHelperPlugin.getRegionIDFromCurrentLocalPointInstanced(client) == 11591;
 	}
 }


### PR DESCRIPTION
### feat(maze): Add support for starting in event

- Added proper support for handling initial runs when (re)starting the plugin when already inside the maze random event


### fix(maze): Fix handling varbit changed events for other events

- Now ignoring VarbitChanged events for Drill Demon and Pirate Chest when fired from within the maze random event
	- Added a maze instance check to the Drill Demon random event for VarbitChanged
	- Added a maze instance check to the Pirate Chest random revent for VarbitChanged

Regarding the VarbitChanged changes, when inside the random event maze, the game modifies varbits associated with the drill demon and pirate chest random events. Not sure why this happens, but I'll early-return out of the event handling to avoid extra logging.