### PR TITLE
[Drill Demon] Add instruction/exercise overlay over demon NPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.6.2'
+version = '2.7.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
@@ -87,7 +87,9 @@ public class DrillDemonHelper
 	@Subscribe
 	public void onNpcSpawned(NpcSpawned npcSpawned)
 	{
-		if (npcSpawned.getNpc().getId() == NpcID.MACRO_DRILLDEMON && this.isInDrillDemonLocalInstance() && this.drillDemonNPC == null)
+		// We want to prio storing the Drill Demon NPC if it's interacting with the player because that one is the correct one in case of edge cases
+		boolean isNPCInteractingWithPlayer = npcSpawned.getNpc().getInteracting() != null && npcSpawned.getNpc().getInteracting().equals(client.getLocalPlayer());
+		if (npcSpawned.getNpc().getId() == NpcID.MACRO_DRILLDEMON && this.isInDrillDemonLocalInstance() && (this.drillDemonNPC == null || isNPCInteractingWithPlayer))
 		{
 			this.drillDemonNPC = npcSpawned.getNpc();
 			if (this.initialRun)

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonOverlay.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.GroundObject;
 import net.runelite.client.ui.overlay.Overlay;
@@ -45,6 +46,18 @@ public class DrillDemonOverlay extends Overlay
 				{
 					OverlayUtil.renderPolygon(graphics2D, combinedMatHull, Color.GREEN);
 				}
+			}
+		}
+
+		if (plugin.getDrillDemonNPC() != null)
+		{
+			if (plugin.getRequestedExercise() != null)
+			{
+				OverlayUtil.renderActorOverlay(graphics2D, plugin.getDrillDemonNPC(), plugin.getRequestedExercise().name(), Color.WHITE);
+			}
+			else
+			{
+				OverlayUtil.renderActorOverlay(graphics2D, plugin.getDrillDemonNPC(), "Talk to Sergeant Damien to determine the required exercise", Color.YELLOW);
 			}
 		}
 		return null;


### PR DESCRIPTION
Added an overlay to the Drill Demon random event NPC to display instructions or the requested exercise to be completed

https://github.com/user-attachments/assets/5f362e36-1cc8-48a1-bfdf-c6af3265bd43

### feat(drilldemon): Add instruction/exercise overlay over demon NPC

- Added tracking the drill demon NPC and the current exercise within DrillDemonHelper
- Ignores the despawned drill demon NPC if we are currently inside the event instance within DrillDemonHelper
	- Should prevent clearing state when someone elses NPC despawns on the occassion there are more than one (rare edge case)
- Added a new overlay within DrillDemonOverlay to render the current requested exercise or instructions to talk to the npc

### fix(drilldemon): Prioritize Drill Demon NPC interacting with player

- Prioritizes the NPC as the one interacting with the player should there be an edge case where there is more than one NPC as in the past

### chore: Update plugin to v2.7.0

- Added an overlay to the Drill Demon random event NPC to display instructions or the requested exercise to be completed