### PR TITLE
Refactor existing lifecycle into a more modular PluginModule 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.7.1'
+version = '3.0.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -77,6 +77,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private PirateHelper pirateHelper;
 
 	@Inject
+	private DrillDemonHelper drillDemonHelper;
+
+	@Inject
 	private MimeHelper mimeHelper;
 
 	@Inject
@@ -93,6 +96,7 @@ public class RandomEventHelperPlugin extends Plugin
 
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
 			.put("isCaptArnavChestEnabled", pirateHelper)
+			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.build();

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -74,6 +74,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private RandomEventHelperItemOverlay itemOverlay;
 
 	@Inject
+	private PirateHelper pirateHelper;
+
+	@Inject
 	private SurpriseExamHelper surpriseExamHelper;
 
 	// <String, PluginModule> -> <configKeyForIsEnabled, PluginModuleInstance>
@@ -86,6 +89,7 @@ public class RandomEventHelperPlugin extends Plugin
 		this.overlayManager.add(itemOverlay);
 
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
+			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.build();
 		// Start only the enabled modules

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -74,6 +74,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private RandomEventHelperItemOverlay itemOverlay;
 
 	@Inject
+	private BeekeeperHelper beekeeperHelper;
+
+	@Inject
 	private PirateHelper pirateHelper;
 
 	@Inject
@@ -95,6 +98,7 @@ public class RandomEventHelperPlugin extends Plugin
 		this.overlayManager.add(itemOverlay);
 
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
+			.put("isBeekeeperEnabled", beekeeperHelper)
 			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isMimeEnabled", mimeHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -37,7 +37,6 @@ import randomeventhelper.randomevents.beekeeper.BeekeeperHelper;
 import randomeventhelper.randomevents.drilldemon.DrillDemonHelper;
 import randomeventhelper.randomevents.freakyforester.FreakyForesterHelper;
 import randomeventhelper.randomevents.gravedigger.GravediggerHelper;
-import randomeventhelper.randomevents.gravedigger.GravediggerOverlay;
 import randomeventhelper.randomevents.maze.MazeHelper;
 import randomeventhelper.randomevents.mime.MimeHelper;
 import randomeventhelper.randomevents.pinball.PinballHelper;
@@ -83,6 +82,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private DrillDemonHelper drillDemonHelper;
 
 	@Inject
+	private GravediggerHelper gravediggerHelper;
+
+	@Inject
 	private MimeHelper mimeHelper;
 
 	@Inject
@@ -107,6 +109,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isBeekeeperEnabled", beekeeperHelper)
 			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
+			.put("isGravediggerEnabled", gravediggerHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isSandwichLadyEnabled", sandwichLadyHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -86,6 +86,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private MimeHelper mimeHelper;
 
 	@Inject
+	private SandwichLadyHelper sandwichLadyHelper;
+
+	@Inject
 	private SurpriseExamHelper surpriseExamHelper;
 
 	@Inject
@@ -105,6 +108,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isMimeEnabled", mimeHelper)
+			.put("isSandwichLadyEnabled", sandwichLadyHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.put("isQuizMasterEnabled", quizMasterHelper)
 			.build();

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -85,6 +85,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private GravediggerHelper gravediggerHelper;
 
 	@Inject
+	private MazeHelper mazeHelper;
+
+	@Inject
 	private MimeHelper mimeHelper;
 
 	@Inject
@@ -110,6 +113,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isGravediggerEnabled", gravediggerHelper)
+			.put("isMazeEnabled", mazeHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isSandwichLadyEnabled", sandwichLadyHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -77,6 +77,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private PirateHelper pirateHelper;
 
 	@Inject
+	private MimeHelper mimeHelper;
+
+	@Inject
 	private SurpriseExamHelper surpriseExamHelper;
 
 	// <String, PluginModule> -> <configKeyForIsEnabled, PluginModuleInstance>
@@ -90,6 +93,7 @@ public class RandomEventHelperPlugin extends Plugin
 
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
 			.put("isCaptArnavChestEnabled", pirateHelper)
+			.put("isMimeEnabled", mimeHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.build();
 		// Start only the enabled modules

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -82,6 +82,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private DrillDemonHelper drillDemonHelper;
 
 	@Inject
+	private FreakyForesterHelper freakyForesterHelper;
+
+	@Inject
 	private GravediggerHelper gravediggerHelper;
 
 	@Inject
@@ -112,6 +115,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isBeekeeperEnabled", beekeeperHelper)
 			.put("isCaptArnavChestEnabled", pirateHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
+			.put("isFreakyForesterEnabled", freakyForesterHelper)
 			.put("isGravediggerEnabled", gravediggerHelper)
 			.put("isMazeEnabled", mazeHelper)
 			.put("isMimeEnabled", mimeHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -73,6 +73,9 @@ public class RandomEventHelperPlugin extends Plugin
 	@Inject
 	private RandomEventHelperItemOverlay itemOverlay;
 
+	@Inject
+	private SurpriseExamHelper surpriseExamHelper;
+
 	// <String, PluginModule> -> <configKeyForIsEnabled, PluginModuleInstance>
 	private Map<String, PluginModule> pluginModulesMap;
 
@@ -83,6 +86,7 @@ public class RandomEventHelperPlugin extends Plugin
 		this.overlayManager.add(itemOverlay);
 
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
+			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.build();
 		// Start only the enabled modules
 		for (PluginModule module : pluginModulesMap.values())

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -94,6 +94,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private MimeHelper mimeHelper;
 
 	@Inject
+	private PinballHelper pinballHelper;
+
+	@Inject
 	private SandwichLadyHelper sandwichLadyHelper;
 
 	@Inject
@@ -119,6 +122,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isGravediggerEnabled", gravediggerHelper)
 			.put("isMazeEnabled", mazeHelper)
 			.put("isMimeEnabled", mimeHelper)
+			.put("isPinballEnabled", pinballHelper)
 			.put("isSandwichLadyEnabled", sandwichLadyHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
 			.put("isQuizMasterEnabled", quizMasterHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -88,6 +88,9 @@ public class RandomEventHelperPlugin extends Plugin
 	@Inject
 	private SurpriseExamHelper surpriseExamHelper;
 
+	@Inject
+	private QuizMasterHelper quizMasterHelper;
+
 	// <String, PluginModule> -> <configKeyForIsEnabled, PluginModuleInstance>
 	private Map<String, PluginModule> pluginModulesMap;
 
@@ -103,6 +106,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isSurpriseExamEnabled", surpriseExamHelper)
+			.put("isQuizMasterEnabled", quizMasterHelper)
 			.build();
 		// Start only the enabled modules
 		for (PluginModule module : pluginModulesMap.values())

--- a/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
+++ b/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
@@ -5,8 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.client.callback.ClientThread;
-import net.runelite.client.config.Config;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.GameEventManager;
@@ -41,6 +39,7 @@ public abstract class PluginModule
 		if (client.getGameState().getState() >= GameState.LOGGED_IN.getState())
 		{
 			// Remember to pass in the instance (this) and not the class (#getClass)
+			// Re-posts NpcSpawned, PlayerSpawned, WallObjectSpawned, DecorativeObjectSpawned, GroundObjectSpawned, GameObjectSpawned, ItemSpawned, WorldEntitySpawned
 			this.gameEventManager.simulateGameEvents(this);
 		}
 		log.debug("Started the {} module", this.getClass().getSimpleName());

--- a/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
+++ b/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
@@ -36,7 +36,7 @@ public abstract class PluginModule
 	{
 		this.eventBus.register(this);
 		this.onStartUp();
-		if (client.getGameState().getState() >= GameState.LOGGED_IN.getState())
+		if (this.client.getGameState().getState() >= GameState.LOGGED_IN.getState())
 		{
 			// Remember to pass in the instance (this) and not the class (#getClass)
 			// Re-posts NpcSpawned, PlayerSpawned, WallObjectSpawned, DecorativeObjectSpawned, GroundObjectSpawned, GameObjectSpawned, ItemSpawned, WorldEntitySpawned
@@ -50,5 +50,10 @@ public abstract class PluginModule
 		this.eventBus.unregister(this);
 		this.onShutdown();
 		log.debug("Shutdown the {} module", this.getClass().getSimpleName());
+	}
+
+	public boolean isLoggedIn()
+	{
+		return this.client.getGameState().getState() >= GameState.LOGGED_IN.getState();
 	}
 }

--- a/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
+++ b/src/main/java/randomeventhelper/pluginmodulesystem/PluginModule.java
@@ -1,0 +1,55 @@
+package randomeventhelper.pluginmodulesystem;
+
+import javax.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.Config;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.GameEventManager;
+import randomeventhelper.RandomEventHelperConfig;
+
+@Slf4j
+// Thanks to Llemon for this - Since we are now relying on constructor injection, we will need a constructor followed by injecting it
+// To keep it a little cleaner, you can still use lombok RAC and also pass in @Inject into it so that the constructor will be injected properly
+// Also, keep in mind that we don't need to define final variables within the module classes themselves since they will be passed in via the constructor injection super call
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public abstract class PluginModule
+{
+	// It's fine to field inject these since we only need access to them here and not in the module classes themselves
+	@Inject
+	protected EventBus eventBus;
+	@Inject
+	protected GameEventManager gameEventManager;
+	protected final OverlayManager overlayManager;
+	protected final RandomEventHelperConfig config;
+	protected final Client client;
+
+	public abstract void onStartUp();
+
+	public abstract void onShutdown();
+
+	public abstract boolean isEnabled();
+
+	public void startUp()
+	{
+		this.eventBus.register(this);
+		this.onStartUp();
+		if (client.getGameState().getState() >= GameState.LOGGED_IN.getState())
+		{
+			// Remember to pass in the instance (this) and not the class (#getClass)
+			this.gameEventManager.simulateGameEvents(this);
+		}
+		log.debug("Started the {} module", this.getClass().getSimpleName());
+	}
+
+	public void shutdown()
+	{
+		this.eventBus.unregister(this);
+		this.onShutdown();
+		log.debug("Shutdown the {} module", this.getClass().getSimpleName());
+	}
+}

--- a/src/main/java/randomeventhelper/randomevents/beekeeper/BeekeeperHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/beekeeper/BeekeeperHelper.java
@@ -15,21 +15,15 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class BeekeeperHelper extends Plugin
+public class BeekeeperHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -42,18 +36,30 @@ public class BeekeeperHelper extends Plugin
 	@Getter
 	private ImmutableList<Widget> beehiveAnswerWidgets;
 
-	public void startUp()
+	@Inject
+	public BeekeeperHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(beekeeperOverlay);
 		this.beehiveAnswerWidgets = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(beekeeperOverlay);
 		this.beehiveAnswerWidgets = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isBeekeeperEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/beekeeper/BeekeeperHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/beekeeper/BeekeeperHelper.java
@@ -47,6 +47,18 @@ public class BeekeeperHelper extends PluginModule
 	{
 		this.overlayManager.add(beekeeperOverlay);
 		this.beehiveAnswerWidgets = null;
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(InterfaceID.Beehive.EXAMPLE) != null)
+				{
+					WidgetLoaded beehiveExampleWidgetLoaded = new WidgetLoaded();
+					beehiveExampleWidgetLoaded.setGroupId(InterfaceID.BEEHIVE);
+					this.eventBus.post(beehiveExampleWidgetLoaded);
+				}
+			});
+		}
 	}
 
 	@Override
@@ -78,10 +90,10 @@ public class BeekeeperHelper extends PluginModule
 					Widget destination4LayerWidget = this.client.getWidget(InterfaceID.Beehive.UNIVERSE_TEXT14);
 					if (destination1LayerWidget != null && destination2LayerWidget != null && destination3LayerWidget != null && destination4LayerWidget != null)
 					{
-						destination1LayerWidget.setText("1. " + destination1LayerWidget.getText());
-						destination2LayerWidget.setText("2. " + destination2LayerWidget.getText());
-						destination3LayerWidget.setText("3. " + destination3LayerWidget.getText());
-						destination4LayerWidget.setText("4. " + destination4LayerWidget.getText());
+						destination1LayerWidget.setText(destination1LayerWidget.getText().contains(".") ? destination1LayerWidget.getText() : "1. " + destination1LayerWidget.getText());
+						destination2LayerWidget.setText(destination2LayerWidget.getText().contains(".") ? destination2LayerWidget.getText() : "2. " + destination2LayerWidget.getText());
+						destination3LayerWidget.setText(destination3LayerWidget.getText().contains(".") ? destination3LayerWidget.getText() : "3. " + destination3LayerWidget.getText());
+						destination4LayerWidget.setText(destination4LayerWidget.getText().contains(".") ? destination4LayerWidget.getText() : "4. " + destination4LayerWidget.getText());
 					}
 					else
 					{

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
@@ -21,22 +21,17 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class DrillDemonHelper
+public class DrillDemonHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private OverlayManager overlayManager;
 
@@ -60,9 +55,15 @@ public class DrillDemonHelper
 	@Getter
 	private DrillExercise requestedExercise;
 
-	public void startUp()
+	@Inject
+	public DrillDemonHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(drillDemonOverlay);
 		this.exerciseMatsAnswerList = Lists.newArrayListWithExpectedSize(4);
 		this.exerciseMatsMultimap = HashMultimap.create(4, 2);
@@ -72,9 +73,9 @@ public class DrillDemonHelper
 		this.requestedExercise = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(drillDemonOverlay);
 		this.exerciseMatsAnswerList = null;
 		this.exerciseMatsMultimap = null;
@@ -82,6 +83,12 @@ public class DrillDemonHelper
 		this.initialRun = true;
 		this.drillDemonNPC = null;
 		this.requestedExercise = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isDrillDemonEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonHelper.java
@@ -74,7 +74,7 @@ public class DrillDemonHelper extends PluginModule
 		this.requestedExercise = null;
 
 		if (this.isLoggedIn()) {
-			this.clientThread.invoke(() ->
+			this.clientThread.invokeLater(() ->
 			{
 				log.debug("Initializing varbits for Drill Demon exercise mappings in case plugin was enabled mid-event.");
 				for (int postVarbitID = VarbitID.MACRO_DRILLDEMON_POST_1; postVarbitID <= VarbitID.MACRO_DRILLDEMON_POST_4; postVarbitID++)

--- a/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
@@ -2,7 +2,6 @@ package randomeventhelper.randomevents.freakyforester;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.google.inject.Provides;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -20,25 +19,18 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.gameval.NpcID;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
 import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class FreakyForesterHelper
+public class FreakyForesterHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private OverlayManager overlayManager;
 
@@ -78,15 +70,15 @@ public class FreakyForesterHelper
 		.put(4, NpcID.MACRO_PHEASANT_MODEL_4)
 		.build();
 
-	@Provides
-	RandomEventHelperConfig provideConfig(ConfigManager configManager)
+	@Inject
+	public FreakyForesterHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		return configManager.getConfig(RandomEventHelperConfig.class);
+		super(overlayManager, config, client);
 	}
 
-	public void startUp()
+	@Override
+	public void onStartUp()
 	{
-		this.eventBus.register(this);
 		this.overlayManager.add(freakyForesterOverlay);
 		this.pheasantHighlightMode = config.pheasantHighlightMode();
 		this.pheasantTailFeathers = 0;
@@ -95,9 +87,9 @@ public class FreakyForesterHelper
 		this.freakyForesterNPC = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(freakyForesterOverlay);
 		this.pheasantTailFeathers = 0;
 		this.pheasantNPCSet = null;
@@ -105,6 +97,12 @@ public class FreakyForesterHelper
 		this.specificPheasantNPC = null;
 		this.initialRun = true;
 		this.freakyForesterNPC = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isFreakyForesterEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterHelper.java
@@ -61,8 +61,6 @@ public class FreakyForesterHelper extends PluginModule
 	@Getter
 	private NPC freakyForesterNPC;
 
-	private boolean initialRun;
-
 	private final Map<Integer, Integer> PHEASANT_TAIL_NPCID_MAP = ImmutableMap.<Integer, Integer>builder()
 		.put(1, NpcID.MACRO_PHEASANT_MODEL_1)
 		.put(2, NpcID.MACRO_PHEASANT_MODEL_2)
@@ -83,7 +81,6 @@ public class FreakyForesterHelper extends PluginModule
 		this.pheasantHighlightMode = config.pheasantHighlightMode();
 		this.pheasantTailFeathers = 0;
 		this.pheasantNPCSet = Sets.newHashSet();
-		this.initialRun = true;
 		this.freakyForesterNPC = null;
 	}
 
@@ -95,7 +92,6 @@ public class FreakyForesterHelper extends PluginModule
 		this.pheasantNPCSet = null;
 		this.nearestPheasantNPC = null;
 		this.specificPheasantNPC = null;
-		this.initialRun = true;
 		this.freakyForesterNPC = null;
 	}
 
@@ -213,12 +209,6 @@ public class FreakyForesterHelper extends PluginModule
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		// In case the player is already in the Freaky Forester instance when the plugin is started
-		if (this.initialRun && this.isInFreakyForesterInstance() && this.pheasantNPCSet.isEmpty())
-		{
-			this.initialRun = false;
-			this.client.getTopLevelWorldView().npcs().stream().filter(npc -> !npc.isDead()).forEach(npc -> this.onNpcSpawned(new NpcSpawned(npc)));
-		}
 		if (this.pheasantHighlightMode == PheasantMode.NEAREST && !this.pheasantNPCSet.isEmpty())
 		{
 			this.updateNearestPheasant();

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerHelper.java
@@ -30,23 +30,18 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class GravediggerHelper
+public class GravediggerHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ItemManager itemManager;
 
@@ -56,6 +51,7 @@ public class GravediggerHelper
 	@Inject
 	private OverlayManager overlayManager;
 
+	@Inject
 	private GravediggerOverlay gravediggerOverlay;
 
 	@Inject
@@ -79,10 +75,15 @@ public class GravediggerHelper
 	@Getter
 	private Set<Integer> coffinsInInventory;
 
-	public void startUp(GravediggerOverlay gravediggerOverlay)
+	@Inject
+	public GravediggerHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.gravediggerOverlay = gravediggerOverlay;
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(this.gravediggerOverlay);
 		this.overlayManager.add(gravediggerItemOverlay);
 		this.initiallyEnteredGraveDiggerArea = true;
@@ -94,13 +95,12 @@ public class GravediggerHelper
 		this.coffinsInInventory = Sets.newHashSetWithExpectedSize(5);
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		if (this.gravediggerOverlay != null)
 		{
 			this.overlayManager.remove(gravediggerOverlay);
-			this.gravediggerOverlay = null;
 		}
 		this.overlayManager.remove(gravediggerItemOverlay);
 		this.initiallyEnteredGraveDiggerArea = true;
@@ -110,6 +110,12 @@ public class GravediggerHelper
 		this.previousInventory = null;
 		this.currentInventoryItems = null;
 		this.coffinsInInventory = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isGravediggerEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/gravedigger/GravediggerOverlay.java
@@ -78,7 +78,13 @@ public class GravediggerOverlay extends Overlay
 					Color placedCoffinTransparentColor = this.getTransparentColor(placedCoffin.getColor(), 50);
 
 					// Renders the check or cross above the grave depending on if the correct coffin is placed
-					Point centeredSpritePoint = Perspective.getCanvasImageLocation(client, grave.getFilledGrave().getLocalLocation(), checkBufferedImage, 0);
+					GameObject graveObject = grave.getFilledGrave() != null ? grave.getFilledGrave() : grave.getEmptyGrave();
+					if (graveObject == null)
+					{
+						continue;
+					}
+
+					Point centeredSpritePoint = Perspective.getCanvasImageLocation(client, graveObject.getLocalLocation(), checkBufferedImage, 0);
 					if (centeredSpritePoint != null)
 					{
 						if (placedCoffin != requiredCoffin)

--- a/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
@@ -18,23 +18,19 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.PluginMessage;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class MazeHelper
+public class MazeHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private PluginManager pluginManager;
 
@@ -48,7 +44,14 @@ public class MazeHelper
 	private boolean isFirstRun;
 	private GameObject mazeExitObject; // Only purpose this serves is to avoid unnecessary onGameTick
 
-	public void startUp()
+	@Inject
+	public MazeHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
+	{
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
 	{
 		Optional<Plugin> shortestPathPlugin = pluginManager.getPlugins().stream().filter(plugin -> plugin.getName().equals("Shortest Path")).findAny();
 
@@ -76,14 +79,13 @@ public class MazeHelper
 			this.configManager.setConfiguration("randomeventhelper", "isMazeEnabled", false);
 			return;
 		}
-		this.eventBus.register(this);
 		this.isFirstRun = true;
 		this.mazeExitObject = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		Optional<Plugin> shortestPathPlugin = pluginManager.getPlugins().stream().filter(plugin -> plugin.getName().equals("Shortest Path")).findAny();
 		if (shortestPathPlugin.isPresent())
 		{
@@ -97,6 +99,12 @@ public class MazeHelper
 		}
 		this.isFirstRun = true;
 		this.mazeExitObject = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isMazeEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
@@ -80,7 +80,7 @@ public class MazeHelper extends PluginModule
 		Optional<Plugin> shortestPathPlugin = pluginManager.getPlugins().stream().filter(plugin -> plugin.getName().equals("Shortest Path")).findAny();
 		if (shortestPathPlugin.isPresent())
 		{
-			if (!pluginManager.isPluginEnabled(shortestPathPlugin.get()))
+			if (pluginManager.isPluginEnabled(shortestPathPlugin.get()))
 			{
 				this.sendShortestPathClear();
 			}

--- a/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
@@ -140,17 +140,22 @@ public class MazeHelper extends PluginModule
 
 	private Map<String, Object> generatePathPayload(WorldPoint destinationWorldPoint)
 	{
-		WorldPoint startingWorldPoint = client.getLocalPlayer().getWorldLocation();
-		if (startingWorldPoint == null)
+		LocalPoint startingLocalPoint = client.getLocalPlayer().getLocalLocation();
+
+		if (startingLocalPoint == null)
 		{
-			log.warn("[#generatePathPayload-WorldPoint] Player's starting world point is null, cannot generate payload starting point");
+			log.warn("[#generatePathPayload(WorldPoint)] Player's starting local point is null, cannot generate payload starting point");
 			return Map.of();
 		}
-		return this.generatePathPayload(startingWorldPoint, destinationWorldPoint);
+
+		WorldPoint localInstanceStartingWorldPoint = WorldPoint.fromLocalInstance(this.client, startingLocalPoint);
+		log.debug("[#generatePathPayload(WorldPoint)] Converted player's local point {} to local instance world point {}", startingLocalPoint, localInstanceStartingWorldPoint);
+		return this.generatePathPayload(localInstanceStartingWorldPoint, destinationWorldPoint);
 	}
 
 	private Map<String, Object> generatePathPayload(WorldPoint startingWorldPoint, WorldPoint destinationWorldPoint)
 	{
+		log.debug("[#generatePathPayload(WorldPoint, WorldPoint)] Generated path payload with starting point: {} and destination point: {}", startingWorldPoint, destinationWorldPoint);
 		return Map.of(
 			"start", startingWorldPoint,
 			"target", destinationWorldPoint

--- a/src/main/java/randomeventhelper/randomevents/mime/MimeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/mime/MimeHelper.java
@@ -14,21 +14,16 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class MimeHelper
+public class MimeHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -49,22 +44,34 @@ public class MimeHelper
 
 	private static final int MIME_RANDOM_EVENT_REGION_ID = 8010;
 
-	public void startUp()
+	@Inject
+	public MimeHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(mimeOverlay);
 		this.mimeNPC = null;
 		this.currentMimeEmote = null;
 		this.mimeEmoteAnswerWidget = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(mimeOverlay);
 		this.mimeNPC = null;
 		this.currentMimeEmote = null;
 		this.mimeEmoteAnswerWidget = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isMimeEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/mime/MimeOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/mime/MimeOverlay.java
@@ -42,10 +42,9 @@ public class MimeOverlay extends Overlay
 		{
 			OverlayUtil.renderPolygon(graphics2D, plugin.getMimeEmoteAnswerWidget().getBounds(), Color.GREEN);
 		}
-		if (plugin.getMimeNPC() != null && plugin.getCurrentMimeEmote() != null)
+		if (plugin.getMimeNPC() != null)
 		{
-			String mimeEmoteText = plugin.getCurrentMimeEmote().name();
-			graphics2D.setFont(graphics2D.getFont().deriveFont(18f));
+			String mimeEmoteText = plugin.getCurrentMimeEmote() != null ? plugin.getCurrentMimeEmote().name() : "Waiting for emote";
 			int mimeHeight = plugin.getMimeNPC().getLogicalHeight();
 			int mimeTextOffset = plugin.getMimeNPC().getAnimationHeightOffset();
 			Point textPoint = plugin.getMimeNPC().getCanvasTextLocation(graphics2D, mimeEmoteText, mimeHeight + mimeTextOffset);

--- a/src/main/java/randomeventhelper/randomevents/pinball/PinballHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/pinball/PinballHelper.java
@@ -15,22 +15,17 @@ import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class PinballHelper
+public class PinballHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private OverlayManager overlayManager;
 
@@ -45,22 +40,34 @@ public class PinballHelper
 
 	private boolean initial = false;
 
-	public void startUp()
+	@Inject
+	public PinballHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(pinballOverlay);
 		this.activePinballPost = null;
 		this.pinballPostsMap = Maps.newHashMap();
 		this.initial = false;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(pinballOverlay);
 		this.activePinballPost = null;
 		this.pinballPostsMap = null;
 		this.initial = false;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isPinballEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/pirate/PirateChestSolver.java
+++ b/src/main/java/randomeventhelper/randomevents/pirate/PirateChestSolver.java
@@ -101,6 +101,7 @@ public class PirateChestSolver
 			log.debug("Pirate chest locks are correctly set.");
 			return true;
 		}
+		this.isSolved = false;
 		log.debug("Pirate chest locks are not correctly set.");
 		return false;
 	}

--- a/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
@@ -57,6 +57,18 @@ public class PirateHelper extends PluginModule
 		this.pirateChestSolver = new PirateChestSolver();
 		this.initiallyLoaded = false;
 		this.widgetMap = Maps.newHashMap();
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(this.CONFIRM_BUTTON_WIDGET_ID) != null)
+				{
+					WidgetLoaded chestConfirmButtonWidgetLoaded = new WidgetLoaded();
+					chestConfirmButtonWidgetLoaded.setGroupId(InterfaceID.PIRATE_COMBILOCK);
+					this.eventBus.post(chestConfirmButtonWidgetLoaded);
+				}
+			});
+		}
 	}
 
 	@Override

--- a/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/pirate/PirateHelper.java
@@ -14,22 +14,17 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperConfig;
 import randomeventhelper.RandomEventHelperPlugin;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class PirateHelper
+public class PirateHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -49,22 +44,34 @@ public class PirateHelper
 	@Getter
 	private Map<Integer, Widget> widgetMap;
 
-	public void startUp()
+	@Inject
+	public PirateHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(pirateOverlay);
 		this.pirateChestSolver = new PirateChestSolver();
 		this.initiallyLoaded = false;
 		this.widgetMap = Maps.newHashMap();
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(pirateOverlay);
 		this.pirateChestSolver = null;
 		this.initiallyLoaded = false;
 		this.widgetMap = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isCaptArnavChestEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterHelper.java
@@ -49,6 +49,18 @@ public class QuizMasterHelper extends PluginModule
 	{
 		this.overlayManager.add(quizMasterOverlay);
 		this.quizAnswerWidget = null;
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(InterfaceID.MacroQuizshow.BUTTONS) != null)
+				{
+					WidgetLoaded quizMasterButtonsWidgetLoaded = new WidgetLoaded();
+					quizMasterButtonsWidgetLoaded.setGroupId(InterfaceID.MACRO_QUIZSHOW);
+					this.eventBus.post(quizMasterButtonsWidgetLoaded);
+				}
+			});
+		}
 	}
 
 	@Override

--- a/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterHelper.java
@@ -17,20 +17,15 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class QuizMasterHelper
+public class QuizMasterHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -43,18 +38,30 @@ public class QuizMasterHelper
 	@Getter
 	private Widget quizAnswerWidget;
 
-	public void startUp()
+	@Inject
+	public QuizMasterHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(quizMasterOverlay);
 		this.quizAnswerWidget = null;
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(quizMasterOverlay);
 		this.quizAnswerWidget = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isQuizMasterEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyHelper.java
@@ -12,21 +12,16 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class SandwichLadyHelper
+public class SandwichLadyHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -42,9 +37,15 @@ public class SandwichLadyHelper
 	private final String SANDWICH_LADY_TRAY_REGEX = "Have a (?<foodName>[\\w\\s]+) for free!";
 	private final Pattern SANDWICH_LADY_PATTERN = Pattern.compile(SANDWICH_LADY_TRAY_REGEX, Pattern.CASE_INSENSITIVE);
 
-	public void startUp()
+	@Inject
+	public SandwichLadyHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(sandwichLadyOverlay);
 		this.trayFoodAnswerWidget = null;
 		WidgetLoaded temp = new WidgetLoaded();
@@ -52,11 +53,18 @@ public class SandwichLadyHelper
 		onWidgetLoaded(temp);
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
 		this.eventBus.unregister(this);
 		this.overlayManager.remove(sandwichLadyOverlay);
 		this.trayFoodAnswerWidget = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isSandwichLadyEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyHelper.java
@@ -48,9 +48,18 @@ public class SandwichLadyHelper extends PluginModule
 	{
 		this.overlayManager.add(sandwichLadyOverlay);
 		this.trayFoodAnswerWidget = null;
-		WidgetLoaded temp = new WidgetLoaded();
-		temp.setGroupId(InterfaceID.SANDWICH_TRAY);
-		onWidgetLoaded(temp);
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(InterfaceID.SandwichTray.SANDWHICH_REFRESHMENT_LAYER) != null)
+				{
+					WidgetLoaded sandwichLadyTrayRefreshmentWidgetLoaded = new WidgetLoaded();
+					sandwichLadyTrayRefreshmentWidgetLoaded.setGroupId(InterfaceID.SANDWICH_TRAY);
+					this.eventBus.post(sandwichLadyTrayRefreshmentWidgetLoaded);
+				}
+			});
+		}
 	}
 
 	@Override

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
@@ -23,20 +23,15 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
 
 @Slf4j
 @Singleton
-public class SurpriseExamHelper
+public class SurpriseExamHelper extends PluginModule
 {
-	@Inject
-	private EventBus eventBus;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private ClientThread clientThread;
 
@@ -111,9 +106,15 @@ public class SurpriseExamHelper
 		InterfaceID.PatternNext.SELECT_3
 	};
 
-	public void startUp()
+	@Inject
+	public SurpriseExamHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
 	{
-		this.eventBus.register(this);
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
 		this.overlayManager.add(overlay);
 		this.patternCardHint = null;
 		this.patternCardAnswers = null;
@@ -123,9 +124,9 @@ public class SurpriseExamHelper
 		this.relationshipSystem = new OSRSItemRelationshipSystem();
 	}
 
-	public void shutDown()
+	@Override
+	public void onShutdown()
 	{
-		this.eventBus.unregister(this);
 		this.overlayManager.remove(overlay);
 		this.patternCardHint = null;
 		this.patternCardAnswers = null;
@@ -133,6 +134,12 @@ public class SurpriseExamHelper
 		this.patternNextAnswer = null;
 		this.patternNextAnswerWidget = null;
 		this.relationshipSystem = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isSurpriseExamEnabled();
 	}
 
 	@Subscribe

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamHelper.java
@@ -122,6 +122,24 @@ public class SurpriseExamHelper extends PluginModule
 		this.patternNextAnswer = null;
 		this.patternNextAnswerWidget = null;
 		this.relationshipSystem = new OSRSItemRelationshipSystem();
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(InterfaceID.PatternCards.HINT) != null)
+				{
+					WidgetLoaded matchingCardsWidgetLoaded = new WidgetLoaded();
+					matchingCardsWidgetLoaded.setGroupId(InterfaceID.PATTERN_CARDS);
+					this.eventBus.post(matchingCardsWidgetLoaded);
+				}
+				if (this.client.getWidget(InterfaceID.PatternNext.UNIVERSE_TEXT12) != null)
+				{
+					WidgetLoaded whatsNextWidgetLoaded = new WidgetLoaded();
+					whatsNextWidgetLoaded.setGroupId(InterfaceID.PATTERN_NEXT);
+					this.eventBus.post(whatsNextWidgetLoaded);
+				}
+			});
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This PR is an attempt to better modularize my existing codebase and plugin lifecycle by using abstraction and primarily constructor injection. The few benefits to this refactor are:
- Cleaner codebase
- Better defined plugin lifecycle
- Better dependency injection handling
- **Re-post various game events** which will eliminate the need to manually refetching the required data on cold starts (with the exception of a few events such as Varbits)

## Events Implemented and Tested
- [x] Beekeeper
- [x] Capt' Arnav's Chest
- [x] Drill Demon
- [x] Freaky Forester
- [x] Gravedigger
- [x] Maze
- [x] Mime
- [x] Pinball
- [x] Sandwich Lady
- [x] Surprise Exam
- [x] Quiz Master


### feat(module): Created PluginModule class for modular plugin lifecycle

- Created an abstract class PluginModule to better handle multiple modules within the plugin and to appropriately handle the lifecycle
	- Construct injected common fields such as OverlayManager, Client, and the config
	- Field injected on-demand fields such as EventBus and GameEventManager
	- Automatically (un)registers the module from the EventBus
	- Re-fire various events by utilizing GameEventManager#simulateGameEvents within #startUp
	- Abstracted #onStartUp to handle module starts, #onShutdown to handle module stops, and #isEnabled to determine the status of the module