### PR TITLE
[Surprise Exam] Fix "shiny things" and "wearing all" matching hint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '2.7.0'
+version = '2.7.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -213,7 +213,7 @@ public class OSRSItemRelationshipSystem
 
 		map.put(RelationshipType.JEWELRY_CRAFTING, Set.of(
 			RandomEventItem.GEM_WITH_CROSS, RandomEventItem.NECKLACE, RandomEventItem.RING,
-			RandomEventItem.HOLY_SYMBOL, RandomEventItem.CAPE_OF_LEGENDS, RandomEventItem.TIARA
+			RandomEventItem.HOLY_SYMBOL, RandomEventItem.TIARA
 		));
 
 		map.put(RelationshipType.LIGHT_FIRE_SYSTEM, Set.of(
@@ -288,8 +288,7 @@ public class OSRSItemRelationshipSystem
 		));
 
 		map.put(RelationshipType.JEWELRY_ACCESSORIES, Set.of(
-			RandomEventItem.NECKLACE, RandomEventItem.RING, RandomEventItem.HOLY_SYMBOL,
-			RandomEventItem.CAPE_OF_LEGENDS
+			RandomEventItem.NECKLACE, RandomEventItem.RING, RandomEventItem.HOLY_SYMBOL
 		));
 
 		map.put(RelationshipType.FACE_ACCESSORIES, Set.of(

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -11,7 +11,7 @@ public enum RelationshipType
 	COOKING_PRODUCTION("cooking, food, chef, kitchen, bread, cake, meals"),
 	ALCOHOL_PRODUCTION("alcohol, brewing, cocktail, beer, rum, gin, drinks"),
 	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus"),
-	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status"),
+	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious"),
 	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination"),
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),
 
@@ -30,7 +30,7 @@ public enum RelationshipType
 	FOOT_ARMOR("feet, boots, footwear, walking, protection"),
 	SHIELDS("shield, defense, blocking, protection, guard"),
 	MELEE_GEAR("melee, sword, scimitar, axe, mace, combat, sharp, helmet, platebody, platelegs, shield"),
-	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, cape, status"),
+	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, status, shiny, precious"),
 	FACE_ACCESSORIES("face, mask, eyepatch, hook, covering, facial"),
 
 	// Skill-based groupings

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -11,7 +11,7 @@ public enum RelationshipType
 	COOKING_PRODUCTION("cooking, food, chef, kitchen, bread, cake, meals"),
 	ALCOHOL_PRODUCTION("alcohol, brewing, cocktail, beer, rum, gin, drinks"),
 	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus"),
-	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious"),
+	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious, wearing all your bangles, bobbles and fineries"),
 	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination"),
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),
 
@@ -30,7 +30,7 @@ public enum RelationshipType
 	FOOT_ARMOR("feet, boots, footwear, walking, protection"),
 	SHIELDS("shield, defense, blocking, protection, guard"),
 	MELEE_GEAR("melee, sword, scimitar, axe, mace, combat, sharp, helmet, platebody, platelegs, shield"),
-	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, status, shiny, precious"),
+	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, status, shiny, precious, wearing all your bangles, bobbles and fineries"),
 	FACE_ACCESSORIES("face, mask, eyepatch, hook, covering, facial"),
 
 	// Skill-based groupings

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -203,6 +203,30 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle11ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle11.getInitialSequenceItems(), puzzle11.getItemChoices());
 		Assertions.assertThat(puzzle11ActualNextMissingItem).isEqualTo(puzzle11.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle12 = new RelationshipSystemTestNextMissingItemData(
+			"[PLATEBODY (27094), BAR (41153), ORE (41170)]",
+			"[LONGBOW (41198), HERRING_OR_MACKEREL (41193), CAPE_OF_LEGENDS (41167), PICKAXE (41194)]",
+			RandomEventItem.PICKAXE
+		);
+		RandomEventItem puzzle12ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle12.getInitialSequenceItems(), puzzle12.getItemChoices());
+		Assertions.assertThat(puzzle12ActualNextMissingItem).isEqualTo(puzzle12.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle13 = new RelationshipSystemTestNextMissingItemData(
+			"[BANANA (41222), STRAWBERRY (41230), GRAPES (41207)]",
+			"[PINEAPPLE (41214), ARROWS (41177), RING (27091), HAMMER (41183)]",
+			RandomEventItem.PINEAPPLE
+		);
+		RandomEventItem puzzle13ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle13.getInitialSequenceItems(), puzzle13.getItemChoices());
+		Assertions.assertThat(puzzle13ActualNextMissingItem).isEqualTo(puzzle13.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle14 = new RelationshipSystemTestNextMissingItemData(
+			"[TUNA (41209), HARPOON (41158), TROUT_COD_PIKE_SALMON_2 (41206)]",
+			"[SHARK (41166), CAKE (41202), COCKTAIL_1 (27097), LONGSWORD (41150)]",
+			RandomEventItem.SHARK
+		);
+		RandomEventItem puzzle14ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle14.getInitialSequenceItems(), puzzle14.getItemChoices());
+		Assertions.assertThat(puzzle14ActualNextMissingItem).isEqualTo(puzzle14.getExpectedNextMissingItem());
 	}
 
 	@Data

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -102,6 +102,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle11ActualItems = relationshipSystem.findItemsByHint(puzzle11.getHint(), puzzle11.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle11ActualItems).containsExactlyInAnyOrderElementsOf(puzzle11.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle12 = new RelationshipSystemTestMatchingData(
+			"There is no better feeling than wearing all your bangles, bobbles and fineries.",
+			"[BONES (2674), AXE (41184), BOTTLE (41175), CHEESE (41161), RING (27091), HARPOON (41158), WATERING_CAN (41213), STAFF (41174), NECKLACE (41216), TROUT_COD_PIKE_SALMON_3 (41163), FIRE_RUNE (41215), WATER_RUNE (41231), HOLY_SYMBOL (41159), TINDERBOX (41154), PICKAXE (41194)]",
+			List.of(RandomEventItem.RING, RandomEventItem.NECKLACE, RandomEventItem.HOLY_SYMBOL)
+		);
+		List<RandomEventItem> puzzle12ActualItems = relationshipSystem.findItemsByHint(puzzle12.getHint(), puzzle12.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle12ActualItems).containsExactlyInAnyOrderElementsOf(puzzle12.getExpectedMatchingItems());
 	}
 
 	@Test

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -94,6 +94,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle10ActualItems = relationshipSystem.findItemsByHint(puzzle10.getHint(), puzzle10.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle10ActualItems).containsExactlyInAnyOrderElementsOf(puzzle10.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle11 = new RelationshipSystemTestMatchingData(
+			"Ooooh, shiny things! Precious things...",
+			"[TINDERBOX (41154), STAFF (41174), HOLY_SYMBOL (41159), WATERING_CAN (41213), FIRE_RUNE (41215), TROUT_COD_PIKE_SALMON_3 (41163), WATER_RUNE (41231), RING (27091), CHEESE (41161), PICKAXE (41194), AXE (41184), NECKLACE (41216), HARPOON (41158), BOTTLE (41175), BONES (2674)]",
+			List.of(RandomEventItem.HOLY_SYMBOL, RandomEventItem.RING, RandomEventItem.NECKLACE)
+		);
+		List<RandomEventItem> puzzle11ActualItems = relationshipSystem.findItemsByHint(puzzle11.getHint(), puzzle11.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle11ActualItems).containsExactlyInAnyOrderElementsOf(puzzle11.getExpectedMatchingItems());
 	}
 
 	@Test


### PR DESCRIPTION
### fix(surpriseexam): Fix matching puzzle hint for "shiny things"

- Fixed the incorrect matching puzzle hint for "Ooooh, shiny things! Precious things..."
	- Thanks to @RSAlxander for pointing out the incorrect puzzle
- Remove CAPE_OF_LEGENDS from JEWELRY_CRAFTING and JEWELRY_ACCESSORIES relationships
- Add "shiny" and "precious" to keywords for JEWELRY_CRAFTING and JEWELRY_ACCESSORIES relationships
- Add "Ooooh, shiny things! Precious things..." to tests

### fix(surpriseexam): Fix matching puzzle hint for "wearing all your bangles"

- Fixed the incorrect matching puzzle hint for "There is no better feeling than wearing all your bangles, bobbles and fineries."
- Add "wearing all your bangles, bobbles and fineries" to keywords for JEWELRY_CRAFTING and JEWELRY_ACCESSORIES relationships
- Add "There is no better feeling than wearing all your bangles, bobbles and fineries." to tests

### test(surpriseexam): Add more tests for missing item puzzles (20251221)

### chore: Update plugin to v2.7.1

- Fixed Surprise Exam random event incorrect matching puzzles with hints "Ooooh, shiny things! Precious things..." and "There is no better feeling than wearing all your bangles, bobbles and fineries."
- Added more Surprise Exam random event test cases

