### PR TITLE
[Maze] ]Improve Shortest Path dependency handling and UX (#48)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.1.0'
+version = '3.1.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/maze/MazeHelper.java
@@ -4,18 +4,18 @@ import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.GameObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.gameval.ObjectID;
-import net.runelite.client.config.ConfigManager;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.PluginChanged;
 import net.runelite.client.events.PluginMessage;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginManager;
@@ -32,11 +32,16 @@ public class MazeHelper extends PluginModule
 	private PluginManager pluginManager;
 
 	@Inject
-	private ConfigManager configManager;
+	private ClientThread clientThread;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
 
 	private static final String PLUGIN_MESSAGE_SHORTEST_PATH_NAMESPACE = "shortestpath";
 	private static final String PLUGIN_MESSAGE_SHORTEST_PATH_PATH_KEY = "path";
 	private static final String PLUGIN_MESSAGE_SHORTEST_PATH_CLEAR_KEY = "clear";
+
+	private GameObject mazeExitObject;
 
 	@Inject
 	public MazeHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
@@ -47,31 +52,8 @@ public class MazeHelper extends PluginModule
 	@Override
 	public void onStartUp()
 	{
-		Optional<Plugin> shortestPathPlugin = pluginManager.getPlugins().stream().filter(plugin -> plugin.getName().equals("Shortest Path")).findAny();
-
-		if (shortestPathPlugin.isPresent())
-		{
-			if (!pluginManager.isPluginEnabled(shortestPathPlugin.get()))
-			{
-				log.warn("[#onStartUp] ShortestPathPlugin is not enabled. Please enable it manually to ensure maze helper's functionality.");
-				this.client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "[Random Event Helper] You've enabled the maze helper module but have the Shortest Path plugin disabled. Please enable it manually to ensure functionality.", null);
-			}
-		}
-		else
-		{
-			log.warn("[#onStartUp] Clue Path Finder requires the Shortest Path plugin found on the Plugin Hub to function properly, and so this plugin has been disabled. Please ensure Shortest Path is installed and enabled before enabling this plugin.");
-			// Show a message popup dialog to the user
-			SwingUtilities.invokeLater(() -> {
-				JOptionPane.showMessageDialog(
-					client.getCanvas(),
-					"Random Event Helper's Maze Helper requires the Shortest Path plugin found on the Plugin Hub to function properly, and so this plugin has been disabled. Please ensure Shortest Path is installed and enabled before enabling Maze support.",
-					"Random Event Helper - Plugin Dependency Missing",
-					JOptionPane.WARNING_MESSAGE
-				);
-			});
-			// Remember to disable Maze config option as well
-			this.configManager.setConfiguration("randomeventhelper", "isMazeEnabled", false);
-		}
+		this.checkShortestPathPluginStatus();
+		this.mazeExitObject = null;
 	}
 
 	@Override
@@ -85,6 +67,7 @@ public class MazeHelper extends PluginModule
 				this.sendShortestPathClear();
 			}
 		}
+		this.mazeExitObject = null;
 	}
 
 	@Override
@@ -100,6 +83,11 @@ public class MazeHelper extends PluginModule
 		{
 			if (gameObjectSpawned.getGameObject() != null)
 			{
+				this.mazeExitObject = gameObjectSpawned.getGameObject();
+				if (!this.checkShortestPathPluginStatus())
+				{
+					return;
+				}
 				LocalPoint shrineLocalPoint = gameObjectSpawned.getGameObject().getLocalLocation();
 				WorldPoint instancedShrineWorldPoint = WorldPoint.fromLocalInstance(this.client, shrineLocalPoint);
 				log.debug("Detected maze exit object spawn, setting shortest path to it");
@@ -114,8 +102,62 @@ public class MazeHelper extends PluginModule
 		if (gameObjectDespawned.getGameObject().getId() == ObjectID.MACRO_MAZE_COMPLETE)
 		{
 			log.debug("Detected maze exit object despawn, clearing shortest path");
+			this.mazeExitObject = null;
 			this.sendShortestPathClear();
 		}
+	}
+
+	@Subscribe
+	public void onPluginChanged(PluginChanged pluginChanged)
+	{
+		log.debug("[#onPluginChanged] Plugin changed: {} | Loaded: {}", pluginChanged.getPlugin().getName(), pluginChanged.isLoaded());
+		if (pluginChanged.getPlugin().getName().equals("Shortest Path") && pluginChanged.isLoaded())
+		{
+			log.debug("[#onPluginChanged] Shortest Path plugin was loaded, re-sending current maze exit object if it exists");
+			if (this.mazeExitObject != null)
+			{
+				GameObjectSpawned gameObjectSpawned = new GameObjectSpawned();
+				gameObjectSpawned.setGameObject(this.mazeExitObject);
+				this.clientThread.invokeLater(() -> {
+					this.onGameObjectSpawned(gameObjectSpawned);
+					log.debug("[#onPluginChanged] Re-sent current maze exit object to Shortest Path plugin after it was enabled");
+				});
+			}
+		}
+	}
+
+	private boolean checkShortestPathPluginStatus()
+	{
+		Optional<Plugin> shortestPathPlugin = pluginManager.getPlugins().stream().filter(plugin -> plugin.getName().equals("Shortest Path")).findAny();
+
+		if (shortestPathPlugin.isPresent())
+		{
+			if (!pluginManager.isPluginEnabled(shortestPathPlugin.get()))
+			{
+				log.warn("[#onStartUp] ShortestPathPlugin is not enabled. Please enable it manually to ensure maze helper's functionality.");
+				if (this.isLoggedIn())
+				{
+					String disabledPluginMessage = RandomEventHelperPlugin.getChatMessageBuilderWithPrefix()
+						.append("You've enabled the maze helper module but have the Shortest Path plugin disabled. Please enable it manually to ensure functionality.")
+						.build();
+					RandomEventHelperPlugin.sendChatMessage(this.chatMessageManager, disabledPluginMessage);
+					return false;
+				}
+			}
+		}
+		else
+		{
+			log.warn("[#onStartUp] Random Event Helper's Maze Helper requires the Shortest Path plugin found on the Plugin Hub to function properly. Please ensure Shortest Path is installed and enabled for Maze pathing support.");
+			if (this.isLoggedIn())
+			{
+				String notInstalledPluginMessage = RandomEventHelperPlugin.getChatMessageBuilderWithPrefix()
+					.append("You've enabled the maze helper module but don't have the Shortest Path plugin installed. Please ensure Shortest Path is installed and enabled for Maze pathing support.")
+					.build();
+				RandomEventHelperPlugin.sendChatMessage(this.chatMessageManager, notInstalledPluginMessage);
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private boolean sendShortestPathDestination(WorldPoint destinationWorldPoint)


### PR DESCRIPTION
### fix(maze): Improve Shortest Path dependency handling and UX (#48)

- Stop automatically disabling the maze helper module when Shortest Path is missing or disabled
	- Fixed an issue where when switching RL profiles, it would disable the Maze Helper module (#48)
- Replace dialog popups with chat-based notifications for missing/disabled Shortest Path
	- Refactor Shortest Path dependency plugin checks into #checkShortestPathPluginStatus
- Regen the maze path when the Shortest Path plugin is (re-)enabled/installed in the middle of the Maze random event
	- Track the current maze exit object to allow re-pathing