### PR TITLE
[Gravedigger] Fix uninitialized state when entering event (#47)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.1.1'
+version = '3.1.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'


### PR DESCRIPTION
### fix(gravedigger): Fix uninitialized state when entering event (#47)

- Fixed an issue where overlays weren't rendering due to the required state not being initialized
	- Refactored initialization code from #onStartUp to a new method #initializeGravediggerState
	- Re-add NpcSpawned listener and call #initializeGravediggerState whenever Gravedigger Leo NPC spawns