### PR TITLE
[Frog] Add support for the Kiss the Frog random event (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,21 @@ https://github.com/user-attachments/assets/b9d810ba-be0b-4b09-a009-9aa5c2be8fb4
 </details>
 <details>
   <summary>Video</summary>
-  
-  https://github.com/user-attachments/assets/d6430888-785e-4d43-90bb-ab98b8b08415
+
+https://github.com/user-attachments/assets/d6430888-785e-4d43-90bb-ab98b8b08415
 </details>
 
 - Helps unlock the chest by highlighting which rotating dial align to the correct item
+
+### [Kiss the Frog](https://oldschool.runescape.wiki/w/Frog_(Kiss_the_frog))
+<details>
+  <summary>Screenshot</summary>
+  <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/6ca312e9-a5ff-4340-a5e0-fc5a36771b67" />
+</details>
+<details>
+  <summary>Video</summary>
+
+_No video at this time_
+</details>
+
+- Highlights the correct frog to interact with

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ https://github.com/user-attachments/assets/d6430888-785e-4d43-90bb-ab98b8b08415
 <details>
   <summary>Video</summary>
 
-_No video at this time_
+https://github.com/user-attachments/assets/6af86020-3245-405b-a194-e5ee42f62a98
 </details>
 
-- Highlights the correct frog to interact with
+- Highlights the Crowned Frog to interact with
+- Highlights the correct positive options to select when interacting with the Crowned Frog

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.2.2'
+version = '3.3.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/RandomEventHelperConfig.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperConfig.java
@@ -125,10 +125,21 @@ public interface RandomEventHelperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "isKissTheFrogEnabled",
+		name = "Kiss the Frog",
+		description = "Helps highlight the correct frog to interact with for the Kiss the Frog random event.",
+		position = 5
+	)
+	default boolean isKissTheFrogEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "isMazeEnabled",
 		name = "Maze",
 		description = "Automatically sets path of Shortest Path plugin to the Strange Shrine in the Maze random event.",
-		position = 5
+		position = 6
 	)
 	default boolean isMazeEnabled()
 	{
@@ -139,7 +150,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isMimeEnabled",
 		name = "Mime",
 		description = "Helps highlight the answers for the Mime random event.",
-		position = 6
+		position = 7
 	)
 	default boolean isMimeEnabled()
 	{
@@ -150,7 +161,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isPinballEnabled",
 		name = "Pinball",
 		description = "Helps highlight the correct pillars to touch for the Pinball random event.",
-		position = 7
+		position = 8
 	)
 	default boolean isPinballEnabled()
 	{
@@ -161,7 +172,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isSandwichLadyEnabled",
 		name = "Sandwich Lady",
 		description = "Helps highlight the correct food to take from the Sandwich Lady random event.",
-		position = 8
+		position = 9
 	)
 	default boolean isSandwichLadyEnabled()
 	{
@@ -172,7 +183,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isSurpriseExamEnabled",
 		name = "Surprise Exam",
 		description = "Helps highlight the answers for the Surprise Exam random event. Supports both matching and next item questions.",
-		position = 9
+		position = 10
 	)
 	default boolean isSurpriseExamEnabled()
 	{
@@ -183,7 +194,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isQuizMasterEnabled",
 		name = "Quiz Master",
 		description = "Helps highlight the correct odd item for the Quiz Master random event.",
-		position = 10
+		position = 11
 	)
 	default boolean isQuizMasterEnabled()
 	{

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -129,7 +129,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isFreakyForesterEnabled", freakyForesterHelper)
 			.put("isGravediggerEnabled", gravediggerHelper)
-			.put("isFrogEnabled", frogHelper)
+			.put("isKissTheFrogEnabled", frogHelper)
 			.put("isMazeEnabled", mazeHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isPinballEnabled", pinballHelper)

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -41,6 +41,7 @@ import randomeventhelper.pluginmodulesystem.PluginModule;
 import randomeventhelper.randomevents.beekeeper.BeekeeperHelper;
 import randomeventhelper.randomevents.drilldemon.DrillDemonHelper;
 import randomeventhelper.randomevents.freakyforester.FreakyForesterHelper;
+import randomeventhelper.randomevents.frog.FrogHelper;
 import randomeventhelper.randomevents.gravedigger.GravediggerHelper;
 import randomeventhelper.randomevents.maze.MazeHelper;
 import randomeventhelper.randomevents.mime.MimeHelper;
@@ -93,6 +94,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private GravediggerHelper gravediggerHelper;
 
 	@Inject
+	private FrogHelper frogHelper;
+
+	@Inject
 	private MazeHelper mazeHelper;
 
 	@Inject
@@ -125,6 +129,7 @@ public class RandomEventHelperPlugin extends Plugin
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isFreakyForesterEnabled", freakyForesterHelper)
 			.put("isGravediggerEnabled", gravediggerHelper)
+			.put("isFrogEnabled", frogHelper)
 			.put("isMazeEnabled", mazeHelper)
 			.put("isMimeEnabled", mimeHelper)
 			.put("isPinballEnabled", pinballHelper)

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
@@ -1,0 +1,174 @@
+package randomeventhelper.randomevents.frog;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.ui.overlay.OverlayManager;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
+
+@Slf4j
+@Singleton
+public class FrogHelper extends PluginModule
+{
+	@Inject
+	private FrogOverlay frogOverlay;
+
+	// https://github.com/runelite/runelite/blob/32a65f18981ef8abdf8369dad59bc1d3679f562b/runelite-client/src/main/java/net/runelite/client/plugins/randomevents/RandomEventPlugin.java#L56
+	private final Set<String> EVENT_OPTIONS = ImmutableSet.of(
+		"Talk-to",
+		"Dismiss"
+	);
+
+	@Getter
+	private NPC crownedFrogNPC;
+
+	private NPC frogCrierNPC;
+
+	@Getter
+	private boolean isEventActiveForPlayer;
+
+	@Inject
+	public FrogHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
+	{
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
+		this.overlayManager.add(frogOverlay);
+		this.crownedFrogNPC = null;
+		this.frogCrierNPC = null;
+		this.isEventActiveForPlayer = false;
+	}
+
+	@Override
+	public void onShutdown()
+	{
+		this.overlayManager.remove(frogOverlay);
+		this.crownedFrogNPC = null;
+		this.frogCrierNPC = null;
+		this.isEventActiveForPlayer = false;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isKissTheFrogEnabled();
+	}
+
+	@Subscribe
+	public void onNpcSpawned(NpcSpawned npcSpawned)
+	{
+		// https://oldschool.runescape.wiki/w/Frog_(Kiss_the_frog)#Crown
+		if (npcSpawned.getNpc().getId() == NpcID.MACRO_FROG_SULKING)
+		{
+			log.debug("Crowned Frog NPC spawned");
+			if (this.crownedFrogNPC != null)
+			{
+				log.debug("Another Crowned Frog NPC has spawned, checking to see which is closer to the local player");
+				WorldPoint localPlayerWorldPoint = this.client.getLocalPlayer().getWorldLocation();
+				int existingCrownedFrogDistanceToPlayer = this.crownedFrogNPC.getWorldLocation().distanceTo(localPlayerWorldPoint);
+				int newCrownedFrogDistanceToPlayer = npcSpawned.getNpc().getWorldLocation().distanceTo(localPlayerWorldPoint);
+				if (newCrownedFrogDistanceToPlayer < existingCrownedFrogDistanceToPlayer)
+				{
+					log.debug("New Crowned Frog NPC is closer to the player therefore replacing the existing one");
+				}
+				else
+				{
+					log.debug("Existing Crowned Frog NPC is closer to the player therefore ignoring the new one");
+					return;
+				}
+			}
+			log.debug("Found Crowned Frog NPC on spawn");
+			this.crownedFrogNPC = npcSpawned.getNpc();
+			this.checkIsEventActiveForPlayer();
+		}
+
+		if (npcSpawned.getNpc().getId() == NpcID.MACRO_FROG_CRIER)
+		{
+			log.debug("Frog Crier NPC spawned | interacting: {}", npcSpawned.getNpc().isInteracting() ? npcSpawned.getNpc().getInteracting().getName() : "NULL");
+			// From basic tests, the Frog Crier when spawned is not interacting with the player (NULL), so this shouldn't even be true... but you never know with race conditions
+			if (npcSpawned.getNpc().isInteracting() && npcSpawned.getNpc().getInteracting().equals(this.client.getLocalPlayer()))
+			{
+				log.debug("Found Frog Crier NPC interacting with the local player on spawn");
+				this.frogCrierNPC = npcSpawned.getNpc();
+				this.checkIsEventActiveForPlayer();
+			}
+		}
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned npcDespawned)
+	{
+		if (this.crownedFrogNPC != null && npcDespawned.getNpc().equals(this.crownedFrogNPC))
+		{
+			log.debug("Known Crowned Frog NPC despawned");
+			this.crownedFrogNPC = null;
+			this.checkIsEventActiveForPlayer();
+		}
+
+		if (this.frogCrierNPC != null && npcDespawned.getNpc().equals(this.frogCrierNPC))
+		{
+			log.debug("Known Frog Crier NPC despawned");
+			this.frogCrierNPC = null;
+			this.checkIsEventActiveForPlayer();
+		}
+	}
+
+	@Subscribe
+	public void onInteractingChanged(InteractingChanged interactingChanged)
+	{
+		if (interactingChanged.getSource() instanceof NPC)
+		{
+			NPC interactingSourceNPC = (NPC) interactingChanged.getSource();
+			if (interactingSourceNPC.getId() == NpcID.MACRO_FROG_CRIER)
+			{
+				Actor interactingTargetActor = interactingChanged.getTarget();
+				if (interactingTargetActor != null && interactingTargetActor.equals(this.client.getLocalPlayer()))
+				{
+					log.debug("Frog Crier NPC is now interacting with the local player");
+					this.frogCrierNPC = interactingSourceNPC;
+					this.checkIsEventActiveForPlayer();
+				}
+				else if (this.frogCrierNPC != null && interactingSourceNPC.equals(this.frogCrierNPC) && (interactingTargetActor == null))
+				{
+					log.debug("Frog Crier NPC is no longer interacting with the local player");
+					this.frogCrierNPC = null;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Checks whether the spawned event is valid by confirming if there is a frogCrierNPC and crownedFrogNPC
+	 */
+	private boolean checkIsEventActiveForPlayer()
+	{
+		if (this.frogCrierNPC != null && this.crownedFrogNPC != null)
+		{
+			log.debug("Found both the Frog Crier NPC and Crowned Frog NPC which indicates the Kiss the Frog random event is for the current player");
+			this.isEventActiveForPlayer = true;
+			return true;
+		}
+		else
+		{
+			log.debug("Could not find both the Frog Crier NPC and Crowned Frog NPC which indicates the Kiss the Frog random event is not active for the current player");
+			this.isEventActiveForPlayer = false;
+			return false;
+		}
+	}
+}

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
@@ -193,9 +193,10 @@ public class FrogHelper extends PluginModule
 					{
 						if (optionWidget != null && optionWidget.getText() != null && !optionWidget.getText().isEmpty())
 						{
-							if (optionWidget.getText().equals("Yes, I'd like to leave now."))
+							String optionText = optionWidget.getText();
+							if (this.isOptionKiss(optionText) || this.isOptionTouch(optionText) || optionText.equals("Yes, I'd like to leave now."))
 							{
-								log.debug("Found 'Yes, I'd like to leave now.' chat menu option which indicates the player is in the dialogue with the Crowned Frog NPC and can leave Frog Land");
+								log.debug("Found chat menu option for \"{}\", highlighting and attaching listeners", optionText);
 								optionWidget.setTextColor(Color.GREEN.getRGB());
 								optionWidget.setOnMouseOverListener((JavaScriptCallback) ev -> {
 									optionWidget.setTextColor(Color.GREEN.getRGB());
@@ -235,6 +236,38 @@ public class FrogHelper extends PluginModule
 			log.debug("Could not find both the Frog Crier NPC and Crowned Frog NPC which indicates the Kiss the Frog random event is not active for the current player");
 			this.isEventActiveForPlayer = false;
 			return false;
+		}
+	}
+
+	private boolean isOptionTouch(String optionText)
+	{
+		switch (optionText)
+		{
+			case "Okay.":
+			case "Alright.":
+			case "All right.":
+			case "Sure, I will.":
+			case "Yeah, okay.":
+			case "I suppose so, sure.":
+			case "Very well, if a touch is all you need, I'll do it.":
+			case "Yes, I will touch you.":
+			case "Sure, I'll touch you.":
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private boolean isOptionKiss(String optionText)
+	{
+		switch (optionText)
+		{
+			case "How about if we kiss?":
+			case "May I kiss you instead? ":
+			case "Would a kiss be acceptable?":
+				return true;
+			default:
+				return false;
 		}
 	}
 

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
@@ -164,11 +164,22 @@ public class FrogHelper extends PluginModule
 			this.isEventActiveForPlayer = true;
 			return true;
 		}
+		else if (this.crownedFrogNPC != null && this.isInFrogLandInstance())
+		{
+			log.debug("Found the Crowned Frog NPC and the player is in the Frog Land instance which indicates the Kiss the Frog random event is for the current player");
+			this.isEventActiveForPlayer = true;
+			return true;
+		}
 		else
 		{
 			log.debug("Could not find both the Frog Crier NPC and Crowned Frog NPC which indicates the Kiss the Frog random event is not active for the current player");
 			this.isEventActiveForPlayer = false;
 			return false;
 		}
+	}
+
+	private boolean isInFrogLandInstance()
+	{
+		return RandomEventHelperPlugin.getRegionIDFromCurrentLocalPointInstanced(client) == 9802;
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogOverlay.java
@@ -1,0 +1,36 @@
+package randomeventhelper.randomevents.frog;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+public class FrogOverlay extends Overlay
+{
+	private final Client client;
+	private final FrogHelper plugin;
+
+	@Inject
+	public FrogOverlay(Client client, FrogHelper plugin)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics2D)
+	{
+		if (this.plugin.isEventActiveForPlayer() && this.plugin.getCrownedFrogNPC() != null)
+		{
+			OverlayUtil.renderPolygon(graphics2D, this.plugin.getCrownedFrogNPC().getConvexHull(), Color.GREEN);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
### feat(frog): Add support for the Kiss the Frog random event

- Created a new PluginModule class FrogHelper to help manage the Frog random event logic
- Created a new Overlay class FrogOverlay to display the relevant overlay for the Frog random event
- Updated the main plugin class RandomEventHelperPlugin to inject and enable FrogHelper
- Updated the plugin config with an option to toggle the Frog random event module

Completes one request made within #45 for additional solver support


STILL REQUIRES A VIDEO FOR THE README UPDATE, though I figure I'll push the changes before that and instead do a basic README update

<img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/aa49cc9d-c5dc-41ad-a8ed-26661c893893" />

Also, I have already tested the changes. However, before pushing the PR I was cleaning up the code a bit and also added `isEventActiveForPlayer` in scenarios where there are multiple same events. Therefore, I'm a bit reluctant to immediately push this without one more confirmation. Though, it shouldn't take a lot of time assuming I get the event. The reason this took so long was because for 1-2 weeks I didn't realize I wasn't injecting the Overlay class and didn't realize it until a few days ago.