### PR TITLE
[Frog] Add missing positive touch chat menu option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.3.0'
+version = '3.3.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogHelper.java
@@ -252,6 +252,7 @@ public class FrogHelper extends PluginModule
 			case "Very well, if a touch is all you need, I'll do it.":
 			case "Yes, I will touch you.":
 			case "Sure, I'll touch you.":
+			case "A touch? Yes, I'll do that.":
 				return true;
 			default:
 				return false;


### PR DESCRIPTION
### fix(frog): Add missing positive touch chat menu option

- Added missing positive touch chat menu option "A touch? Yes, I'll do that."