### PR TITLE
[Surprise Exam] Fix "igniting my brain" matching card question hint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.3.1'
+version = '3.3.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -12,7 +12,7 @@ public enum RelationshipType
 	ALCOHOL_PRODUCTION("alcohol, brewing, cocktail, beer, rum, gin, drinks"),
 	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus"),
 	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious, wearing all your bangles, bobbles and fineries"),
-	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination"),
+	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination, ignite, igniting"),
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),
 
 	// Thematic groups

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -144,6 +144,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle16ActualItems = relationshipSystem.findItemsByHint(puzzle16.getHint(), puzzle16.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle16ActualItems).containsExactlyInAnyOrderElementsOf(puzzle16.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle17 = new RelationshipSystemTestMatchingData(
+			"This pattern is igniting my brain.",
+			"[TROUT_COD_PIKE_SALMON_3, CANDLE_LANTERN, CUP_OF_TEA, LONGSWORD, LEDERHOSEN_HAT, TUNA, WATERING_CAN, LOGS, GEM_WITH_CROSS, HARPOON, PICKAXE, TINDERBOX, BOTTLE, KEY,HAMMER]",
+			List.of(RandomEventItem.CANDLE_LANTERN, RandomEventItem.LOGS, RandomEventItem.TINDERBOX)
+		);
+		List<RandomEventItem> puzzle17ActualItems = relationshipSystem.findItemsByHint(puzzle17.getHint(), puzzle17.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle17ActualItems).containsExactlyInAnyOrderElementsOf(puzzle17.getExpectedMatchingItems());
 	}
 
 	@Test

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -168,7 +168,7 @@ public class RelationshipSystemTest
 
 		RelationshipSystemTestNextMissingItemData puzzle3 = new RelationshipSystemTestNextMissingItemData(
 			"[NECKLACE (41216), TIARA (41148), HOLY_SYMBOL (41159)]",
-			"[HAMMER (41183), RING (27091), HERRING_OR_MACKEREL (41193)]",
+			"[HAMMER (41183), RING (27091), BEER (41152), HERRING_OR_MACKEREL (41193)]",
 			RandomEventItem.RING
 		);
 		RandomEventItem puzzle3ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle3.getInitialSequenceItems(), puzzle3.getItemChoices());


### PR DESCRIPTION
### test(surpriseexam): Add missing item to testNextMissingItem test case

### fix(surpriseexam): Fix matching card question hint for "igniting my brain"

- Added new keywords "ignite" and "igniting" to LIGHT_FIRE_SYSTEM RelationshipType
- Added new test case to testPatternMatching for the hint "This pattern is igniting my brain."

### chore: Update plugin to v3.3.2

- Fixed Surprise Exam random event incorrect matching card question with hint "This pattern is igniting my brain."
- Added a new Surprise Exam random event test case and updated another

---

Note, I ended up fixing this by hard-coding the word from the question as I did with some other hints too. The better thing to do would be to start using word embeddings or sentiments, but that delves into NLP territory. That's not a problem, but I don't want to bother with third-party dependencies and RL approval for them. Furthermore, from brief research, there is OpenNLP, but it'll add additional memory usage and I don't want to waste resources when I don't have to since this solution works well enough without all that overhead from NLP.