### PR TITLE
[Surprise Exam] Fixed various incorrect pattern matching questions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.3.2'
+version = '3.3.3'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -102,12 +102,13 @@ public class OSRSItemRelationshipSystem
 	private final Set<String> NEGATION_WORDS = Set.of("not", "dont", "don't", "no", "never", "hate", "avoid", "against");
 
 	private final Map<String, Set<RelationshipType>> NEGATION_OPPOSITE_MAP = Map.ofEntries(
-		Map.entry("ranged", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR)),
-		Map.entry("ranging", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR)),
-		Map.entry("range", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR)),
-		Map.entry("melee", Set.of(RelationshipType.RANGED_WEAPONS)),
-		Map.entry("magic", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.RANGED_WEAPONS)),
-		Map.entry("spell", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.RANGED_WEAPONS))
+		Map.entry("ranged", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR, RelationshipType.MAGIC_RUNES, RelationshipType.MAGIC_RUNECRAFTING)),
+		Map.entry("ranging", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR, RelationshipType.MAGIC_RUNES, RelationshipType.MAGIC_RUNECRAFTING)),
+		Map.entry("range", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR, RelationshipType.MAGIC_RUNES, RelationshipType.MAGIC_RUNECRAFTING)),
+		Map.entry("melee", Set.of(RelationshipType.RANGED_WEAPONS, RelationshipType.MAGIC_RUNES, RelationshipType.MAGIC_RUNECRAFTING)),
+		Map.entry("magic", Set.of(RelationshipType.RANGED_WEAPONS, RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR)),
+		Map.entry("mage", Set.of(RelationshipType.RANGED_WEAPONS, RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR)),
+		Map.entry("spell", Set.of(RelationshipType.RANGED_WEAPONS, RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR))
 	);
 
 	public OSRSItemRelationshipSystem()
@@ -116,6 +117,27 @@ public class OSRSItemRelationshipSystem
 		this.jaroWinklerDistance = new JaroWinklerDistance();
 	}
 
+	/**
+	 * Detects tokens in the riddle that are likely negated.
+	 *
+	 * <p>
+	 * This method analyzes the riddle text and identifies words that appear to be
+	 * negated by phrases such as <i>no</i>, <i>not</i>, <i>without</i>, or <i>hate</i>.
+	 * These tokens can then be excluded from further matching logic.
+	 * </p>
+	 *
+	 * <p><b>Example</b></p>
+	 * <pre>
+	 * Input:
+	 *   "Tools for warriors who hate ranging or magic."
+	 *
+	 * Output:
+	 *   ["ranging", "magic"]
+	 * </pre>
+	 *
+	 * @param riddle The riddle or hint text to analyze.
+	 * @return A {@code Set<String>} containing tokens that are likely negated within the provided riddle text.
+	 */
 	private Set<String> detectNegatedTokens(String riddle)
 	{
 		Set<String> negated = new HashSet<>();
@@ -229,11 +251,12 @@ public class OSRSItemRelationshipSystem
 		// Thematic groups
 		map.put(RelationshipType.PIRATE_THEME, Set.of(
 			RandomEventItem.PIRATE_HAT, RandomEventItem.PIRATE_BOOTS, RandomEventItem.PIRATE_HOOK,
-			RandomEventItem.EYE_PATCH, RandomEventItem.KEY, RandomEventItem.HIGHWAYMAN_MASK
+			RandomEventItem.EYE_PATCH, RandomEventItem.HIGHWAYMAN_MASK
 		));
 
 		map.put(RelationshipType.ENTERTAINMENT_THEME, Set.of(
-			RandomEventItem.JESTER_HAT, RandomEventItem.MIME_MASK, RandomEventItem.FROG_MASK, RandomEventItem.HIGHWAYMAN_MASK
+			RandomEventItem.JESTER_HAT, RandomEventItem.MIME_MASK, RandomEventItem.FROG_MASK, RandomEventItem.HIGHWAYMAN_MASK,
+			RandomEventItem.LEDERHOSEN_HAT, RandomEventItem.PIRATE_HAT
 		));
 
 		map.put(RelationshipType.PROFESSIONAL_THEME, Set.of(
@@ -449,18 +472,59 @@ public class OSRSItemRelationshipSystem
 		// Step 2: Expand keywords using context clues and synonyms
 		Set<String> expandedKeywords = expandWithContextAndSynonyms(riddleKeywords);
 
-		// Step 2.5: detect any negated tokens from hint (eg: "hate ranging or magic")
-		Set<String> negatedTokens = detectNegatedTokens(riddle);
+		// Step 2.5: detect any negated tokens from hint (eg: "hate ranging or magic" -> "ranging" and "magic" are negated)
+		Set<String> detectedNegatedTokens = detectNegatedTokens(riddle);
 
 		// Step 3: Score each relationship type based on keyword matches
+		// --- Advanced negation logic for combat styles ---
+		// If hint negates 2+ of melee, magic, range, boost the remaining style(s)
+		Set<String> combatStyles = Set.of("ranged", "ranging", "range", "melee", "magic", "mage", "spell");
+		Set<String> negatedCombatStyleKeys = new HashSet<>();
+		for (String neg : detectedNegatedTokens)
+		{
+			String n = neg.toLowerCase();
+			if (combatStyles.contains(n))
+			{
+				if (n.equals("ranged") || n.equals("ranging"))
+				{
+					n = "range";
+				}
+				if (n.equals("mage") || n.equals("spell"))
+				{
+					n = "magic";
+				}
+				negatedCombatStyleKeys.add(n);
+			}
+		}
+
+		// Map combat style to relationship
+		Map<String, Set<RelationshipType>> styleToRel = Map.of(
+			"melee", Set.of(RelationshipType.MELEE_WEAPONS, RelationshipType.MELEE_GEAR),
+			"magic", Set.of(RelationshipType.MAGIC_RUNES, RelationshipType.MAGIC_RUNECRAFTING),
+			"range", Set.of(RelationshipType.RANGED_WEAPONS)
+		);
+
+		Set<RelationshipType> boostableCombatStyleRelationshipTypes = new HashSet<>();
+		if (negatedCombatStyleKeys.size() >= 2)
+		{
+			// Boost the remaining style(s)
+			for (String style : styleToRel.keySet())
+			{
+				if (!negatedCombatStyleKeys.contains(style))
+				{
+					boostableCombatStyleRelationshipTypes.addAll(styleToRel.get(style));
+				}
+			}
+		}
+
 		for (RelationshipType type : RelationshipType.values())
 		{
 			double score = calculateRelationshipScore(type, expandedKeywords, riddleKeywords);
 			// Apply negation handling: if the relationship contains a negated token, penalize it
-			if (!negatedTokens.isEmpty())
+			if (!detectedNegatedTokens.isEmpty())
 			{
 				boolean containsNegated = false;
-				for (String neg : negatedTokens)
+				for (String neg : detectedNegatedTokens)
 				{
 					for (String relkw : type.getKeywordArray())
 					{
@@ -481,7 +545,7 @@ public class OSRSItemRelationshipSystem
 				}
 
 				// For negated tokens, if we have an opposite relationship mapping, boost the opposite(s)
-				for (String neg : negatedTokens)
+				for (String neg : detectedNegatedTokens)
 				{
 					Set<RelationshipType> opposites = NEGATION_OPPOSITE_MAP.get(neg.toLowerCase());
 					if (opposites != null && opposites.contains(type))
@@ -490,6 +554,11 @@ public class OSRSItemRelationshipSystem
 						break;
 					}
 				}
+			}
+			// Advanced: boost remaining (opposite) combat style if 2+ are negated
+			if (boostableCombatStyleRelationshipTypes.contains(type))
+			{
+				score *= 2.0; // Strong boost for the only remaining style
 			}
 			if (score > 0)
 			{

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -11,13 +11,13 @@ public enum RelationshipType
 	COOKING_PRODUCTION("cooking, food, chef, kitchen, bread, cake, meals"),
 	ALCOHOL_PRODUCTION("alcohol, brewing, cocktail, beer, rum, gin, drinks"),
 	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus"),
-	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious, wearing all your bangles, bobbles and fineries"),
+	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious, wearing all your bangles, bobbles and fineries, accessory, accessories, silver, gold"),
 	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination, ignite, igniting"),
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),
 
 	// Thematic groups
 	PIRATE_THEME("pirate, sea, nautical, hook, eyepatch, boots, hat, yarr, crime, strange"),
-	ENTERTAINMENT_THEME("entertainment, performance, jester, mime, mask, fun, clown, fool, mask, face, strange"),
+	ENTERTAINMENT_THEME("entertainment, performance, jester, mime, mask, fun, clown, fool, mask, face, strange, hairstyle, garment, garments"),
 	PROFESSIONAL_THEME("profession, work, chef, trade, job, occupation"),
 
 	// Equipment categories
@@ -30,7 +30,7 @@ public enum RelationshipType
 	FOOT_ARMOR("feet, boots, footwear, walking, protection"),
 	SHIELDS("shield, defense, blocking, protection, guard"),
 	MELEE_GEAR("melee, sword, scimitar, axe, mace, combat, sharp, helmet, platebody, platelegs, shield"),
-	JEWELRY_ACCESSORIES("jewelry, accessories, necklace, ring, status, shiny, precious, wearing all your bangles, bobbles and fineries"),
+	JEWELRY_ACCESSORIES("jewelry, accessories, accessory, necklace, ring, status, shiny, precious, wearing all your bangles, bobbles and fineries, silver, gold"),
 	FACE_ACCESSORIES("face, mask, eyepatch, hook, covering, facial"),
 
 	// Skill-based groupings
@@ -44,8 +44,8 @@ public enum RelationshipType
 	FISH("fish, raw, uncooked, sea, food, sea food, seafood, fishing, water"),
 	FRUITS("fruits, berries, fresh, healthy, vitamins, nature"),
 	BAKING_FOOD("cooked, food, meals, prepared, baked, ready"),
-	ALCOHOLIC_DRINKS("alcohol, drinks, beer, spirits, intoxicating, beverages, thirsty"),
-	DRINKS("drink, beverage, refreshing, hydrate, quench, thirsty, liquid, sip"),
+	ALCOHOLIC_DRINKS("alcohol, drinks, beer, spirits, intoxicating, beverages, thirsty, dehydrated"),
+	DRINKS("drink, beverage, refreshing, hydrate, quench, thirsty, liquid, sip, dehydrated"),
 
 	// Functional groupings
 	COMBAT_CONSUMABLES("combat, consumable, potion, bones, prayer, aid"),

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -111,15 +111,13 @@ public class RelationshipSystemTest
 		List<RandomEventItem> puzzle12ActualItems = relationshipSystem.findItemsByHint(puzzle12.getHint(), puzzle12.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle12ActualItems).containsExactlyInAnyOrderElementsOf(puzzle12.getExpectedMatchingItems());
 
-		// Needs more info - https://github.com/Infinitay/Random-Event-Helper/issues/33#issuecomment-3786983409
-		/*
 		RelationshipSystemTestMatchingData puzzle13 = new RelationshipSystemTestMatchingData(
 			"Piracy is a crime, but go find the pattern anyway.",
 			"[CUP_OF_TEA (41162), ORE (41170), KEY (29232), LONGSWORD (41150), WATER_RUNE (41231), STAFF (41174), NECKLACE (41216), PIRATE_HOOK (41228), EYE_PATCH (41165), FIRE_RUNE (41215), BASS (41180), STAFF (41174), BONES (2674), PIE (41205), PIRATE_HAT (41187)]",
-			List.of(RandomEventItem.PIRATE_HOOK, RandomEventItem.EYE_PATCH, RandomEventItem.KEY)
+			List.of(RandomEventItem.PIRATE_HOOK, RandomEventItem.EYE_PATCH, RandomEventItem.PIRATE_HAT)
 		);
 		List<RandomEventItem> puzzle13ActualItems = relationshipSystem.findItemsByHint(puzzle13.getHint(), puzzle13.getGivenItems(), 3).subList(0, 3);
-		Assertions.assertThat(puzzle13ActualItems).containsExactlyInAnyOrderElementsOf(puzzle13.getExpectedMatchingItems());*/
+		Assertions.assertThat(puzzle13ActualItems).containsExactlyInAnyOrderElementsOf(puzzle13.getExpectedMatchingItems());
 
 		RelationshipSystemTestMatchingData puzzle14 = new RelationshipSystemTestMatchingData(
 			"I'm feeling dehydrated.",
@@ -152,6 +150,46 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle17ActualItems = relationshipSystem.findItemsByHint(puzzle17.getHint(), puzzle17.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle17ActualItems).containsExactlyInAnyOrderElementsOf(puzzle17.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle18 = new RelationshipSystemTestMatchingData(
+			"Pretty accessories made from silver and gold.",
+			"[HOLY_SYMBOL, TROUT_COD_PIKE_SALMON_3, BONES, WATERING_CAN, TINDERBOX, WATER_RUNE, CHEESE, BOTTLE, PICKAXE, HARPOON, NECKLACE, RING, AXE, STAFF, FIRE_RUNE]",
+			List.of(RandomEventItem.HOLY_SYMBOL, RandomEventItem.NECKLACE, RandomEventItem.RING)
+		);
+		List<RandomEventItem> puzzle18ActualItems = relationshipSystem.findItemsByHint(puzzle18.getHint(), puzzle18.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle18ActualItems).containsExactlyInAnyOrderElementsOf(puzzle18.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle19 = new RelationshipSystemTestMatchingData(
+			"Wear one of these when you don't want to be recognised.",
+			"[MIME_MASK, KITCHEN_KNIFE, TROUT_COD_PIKE_SALMON_3, BATTLE_AXE, THREAD, JUG, LONGBOW, FROG_MASK, SCIMITAR, HIGHWAYMAN_MASK, SPADE, CANDLE_LANTERN, POTION, ONION, BAR]",
+			List.of(RandomEventItem.MIME_MASK, RandomEventItem.FROG_MASK, RandomEventItem.HIGHWAYMAN_MASK)
+		);
+		List<RandomEventItem> puzzle19ActualItems = relationshipSystem.findItemsByHint(puzzle19.getHint(), puzzle19.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle19ActualItems).containsExactlyInAnyOrderElementsOf(puzzle19.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle20 = new RelationshipSystemTestMatchingData(
+			"Don't let these garments mess up your hairstyle.",
+			"[PLATELEGS, TINDERBOX, LONGSWORD, POT, PIRATE_HAT, TROUT_COD_PIKE_SALMON_3, SHARK, CAKE, BONES, JESTER_HAT, LEDERHOSEN_HAT, ORE, AXE, ARROWS, NECKLACE]",
+			List.of(RandomEventItem.PIRATE_HAT, RandomEventItem.JESTER_HAT, RandomEventItem.LEDERHOSEN_HAT)
+		);
+		List<RandomEventItem> puzzle20ActualItems = relationshipSystem.findItemsByHint(puzzle20.getHint(), puzzle20.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle20ActualItems).containsExactlyInAnyOrderElementsOf(puzzle20.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle21 = new RelationshipSystemTestMatchingData(
+			"Yarr, 'tis a fine puzzle for landlubbers.",
+			"[PIE, ORE, NECKLACE, BONES, STAFF, KEY, WATER_RUNE, FIRE_RUNE, CUP_OF_TEA, PIRATE_HAT, PIRATE_HOOK, BASS, LONGSWORD, EYE_PATCH, STAFF]",
+			List.of(RandomEventItem.PIRATE_HAT, RandomEventItem.PIRATE_HOOK, RandomEventItem.EYE_PATCH)
+		);
+		List<RandomEventItem> puzzle21ActualItems = relationshipSystem.findItemsByHint(puzzle21.getHint(), puzzle21.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle21ActualItems).containsExactlyInAnyOrderElementsOf(puzzle21.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle22 = new RelationshipSystemTestMatchingData(
+			"Patterns really light my fire.",
+			"[KEY, TROUT_COD_PIKE_SALMON_3, HAMMER, TUNA, TINDERBOX, CUP_OF_TEA, GEM_WITH_CROSS, WATERING_CAN, LOGS, LONGSWORD, PICKAXE, CANDLE_LANTERN, HARPOON, BOTTLE, LEDERHOSEN_HAT]",
+			List.of(RandomEventItem.TINDERBOX, RandomEventItem.LOGS, RandomEventItem.CANDLE_LANTERN)
+		);
+		List<RandomEventItem> puzzle22ActualItems = relationshipSystem.findItemsByHint(puzzle22.getHint(), puzzle22.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle22ActualItems).containsExactlyInAnyOrderElementsOf(puzzle22.getExpectedMatchingItems());
 	}
 
 	@Test
@@ -293,6 +331,22 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle17ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle17.getInitialSequenceItems(), puzzle17.getItemChoices());
 		Assertions.assertThat(puzzle17ActualNextMissingItem).isEqualTo(puzzle17.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle18 = new RelationshipSystemTestNextMissingItemData(
+			"[PIRATE_BOOTS, INSULATED_BOOTS, FIGHTER_BOOTS]",
+			"[LEATHER_BOOTS, BOTTLE, PLATELEGS, LEDERHOSEN_HAT]",
+			RandomEventItem.LEATHER_BOOTS
+		);
+		RandomEventItem puzzle18ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle18.getInitialSequenceItems(), puzzle18.getItemChoices());
+		Assertions.assertThat(puzzle18ActualNextMissingItem).isEqualTo(puzzle18.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle19 = new RelationshipSystemTestNextMissingItemData(
+			"[PICKAXE, ORE, HAMMER]",
+			"[CANDLE_LANTERN, BAR, COCKTAIL_1, POTION]",
+			RandomEventItem.BAR
+		);
+		RandomEventItem puzzle19ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle19.getInitialSequenceItems(), puzzle19.getItemChoices());
+		Assertions.assertThat(puzzle19ActualNextMissingItem).isEqualTo(puzzle19.getExpectedNextMissingItem());
 	}
 
 	@Data


### PR DESCRIPTION
### fix(surpriseexam): Fixed incorrect Surprise Exam pattern matching questions

- Fixed various incorrect Surprise exam pattern matching questions
	- Pattern Matching
		- "Pretty accessories made from silver and gold."
		- "Don't let these garments mess up your hairstyle"
		- "Yarr, 'tis a fine puzzle for landlubbers."
- Updated keywords for relevant RelationshipType
	- JEWELRY_CRAFTING, JEWELRY_ACCESSORIES, ENTERTAINMENT_THEME, ALCOHOLIC_DRINKS, DRINKS
- Modified OSRSItemRelationshipSystem 
	- Added more negation combat styles
	- Removed RandomEventItem KEY from Pirate Relationship
	- Added more hats and masks to the Entertainment Relationship
	- Added documentation to #detectNegatedTokens
	- Improved #analyzeRiddleAndFindItems negation scoring
		- Now specifically handles negating combat style(s) and boosts the score for the appropriate style
- Added new test cases to testPatternMatching and testNextMissingItem


### chore: Update plugin to v3.3.3

- Fixed Surprise Exam random event incorrect pattern matching card questions
	- "Pretty accessories made from silver and gold."
	- "Don't let these garments mess up your hairstyle"
	- "Yarr, 'tis a fine puzzle for landlubbers."
- Updated keywords for various RelationshipTypes
- Modified the OSRSItemRelationshipSystem relationships and negation scoring for combat styles

---

Closes #62. Thanks to @NordicRest and @SeriouslyRain for reporting the various incorrect questions.