### PR TITLE
[Certer] Add support for the Certer random event (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,16 @@ https://github.com/user-attachments/assets/6af86020-3245-405b-a194-e5ee42f62a98
 
 - Highlights the Crowned Frog to interact with
 - Highlights the correct positive options to select when interacting with the Crowned Frog
+
+### [Certer (Giles/Miles/Niles)](https://oldschool.runescape.wiki/w/Certer)
+<details>
+  <summary>Screenshot</summary>
+  <img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/d28cf029-981c-44dd-b28c-848b9e69fe2d" />
+</details>
+<details>
+  <summary>Video</summary>
+
+https://github.com/user-attachments/assets/91eb28a1-cd52-4837-9751-5f055f14b480
+</details>
+
+- Highlights the correct answer to the question asked by Certer of which item is being displayed

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.3.4'
+version = '3.4.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/RandomEventHelperConfig.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperConfig.java
@@ -34,10 +34,21 @@ public interface RandomEventHelperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "isCerterEnabled",
+		name = "Certer (Giles/Miles/Niles)",
+		description = "Helps highlight the correct item being displayed during the Certer's random event.",
+		position = 2
+	)
+	default boolean isCerterEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "isDrillDemonEnabled",
 		name = "Drill Demon",
 		description = "Helps highlight the correct exercise mat for the Drill Demon random event.",
-		position = 2
+		position = 3
 	)
 	default boolean isDrillDemonEnabled()
 	{
@@ -47,7 +58,7 @@ public interface RandomEventHelperConfig extends Config
 	@ConfigSection(
 		name = "Freaky Forester",
 		description = "Freaky Forester random event options",
-		position = 3,
+		position = 4,
 		closedByDefault = true
 	)
 	String SECTION_FREAKY_FORESTER = "sectionFreakyForester";
@@ -79,7 +90,7 @@ public interface RandomEventHelperConfig extends Config
 	@ConfigSection(
 		name = "Gravedigger",
 		description = "Gravedigger random event options",
-		position = 4,
+		position = 5,
 		closedByDefault = true
 	)
 	String SECTION_GRAVEDIGGER = "sectionGravedigger";
@@ -128,7 +139,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isKissTheFrogEnabled",
 		name = "Kiss the Frog",
 		description = "Helps highlight the correct frog to interact with for the Kiss the Frog random event.",
-		position = 5
+		position = 6
 	)
 	default boolean isKissTheFrogEnabled()
 	{
@@ -139,7 +150,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isMazeEnabled",
 		name = "Maze",
 		description = "Automatically sets path of Shortest Path plugin to the Strange Shrine in the Maze random event.",
-		position = 6
+		position = 7
 	)
 	default boolean isMazeEnabled()
 	{
@@ -150,7 +161,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isMimeEnabled",
 		name = "Mime",
 		description = "Helps highlight the answers for the Mime random event.",
-		position = 7
+		position = 8
 	)
 	default boolean isMimeEnabled()
 	{
@@ -161,7 +172,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isPinballEnabled",
 		name = "Pinball",
 		description = "Helps highlight the correct pillars to touch for the Pinball random event.",
-		position = 8
+		position = 9
 	)
 	default boolean isPinballEnabled()
 	{
@@ -172,7 +183,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isSandwichLadyEnabled",
 		name = "Sandwich Lady",
 		description = "Helps highlight the correct food to take from the Sandwich Lady random event.",
-		position = 9
+		position = 10
 	)
 	default boolean isSandwichLadyEnabled()
 	{
@@ -183,7 +194,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isSurpriseExamEnabled",
 		name = "Surprise Exam",
 		description = "Helps highlight the answers for the Surprise Exam random event. Supports both matching and next item questions.",
-		position = 10
+		position = 11
 	)
 	default boolean isSurpriseExamEnabled()
 	{
@@ -194,7 +205,7 @@ public interface RandomEventHelperConfig extends Config
 		keyName = "isQuizMasterEnabled",
 		name = "Quiz Master",
 		description = "Helps highlight the correct odd item for the Quiz Master random event.",
-		position = 11
+		position = 12
 	)
 	default boolean isQuizMasterEnabled()
 	{

--- a/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperPlugin.java
@@ -40,6 +40,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import randomeventhelper.pluginmodulesystem.PluginModule;
 import randomeventhelper.randomevents.beekeeper.BeekeeperHelper;
+import randomeventhelper.randomevents.certer.CerterHelper;
 import randomeventhelper.randomevents.drilldemon.DrillDemonHelper;
 import randomeventhelper.randomevents.freakyforester.FreakyForesterHelper;
 import randomeventhelper.randomevents.frog.FrogHelper;
@@ -86,6 +87,9 @@ public class RandomEventHelperPlugin extends Plugin
 	private PirateHelper pirateHelper;
 
 	@Inject
+	private CerterHelper certerHelper;
+
+	@Inject
 	private DrillDemonHelper drillDemonHelper;
 
 	@Inject
@@ -127,6 +131,7 @@ public class RandomEventHelperPlugin extends Plugin
 		pluginModulesMap = ImmutableMap.<String, PluginModule>builder()
 			.put("isBeekeeperEnabled", beekeeperHelper)
 			.put("isCaptArnavChestEnabled", pirateHelper)
+			.put("isCerterEnabled", certerHelper)
 			.put("isDrillDemonEnabled", drillDemonHelper)
 			.put("isFreakyForesterEnabled", freakyForesterHelper)
 			.put("isGravediggerEnabled", gravediggerHelper)

--- a/src/main/java/randomeventhelper/randomevents/certer/CerterEventItem.java
+++ b/src/main/java/randomeventhelper/randomevents/certer/CerterEventItem.java
@@ -1,0 +1,67 @@
+package randomeventhelper.randomevents.certer;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CerterEventItem
+{
+	BOWL("A bowl.", 2807),
+	RING("A ring.", 8834),
+	AXE("An axe.", 8828),
+	KITE_SHIELD("A shield.", 8832),
+	SHEARS("A pair of shears.", 8835),
+	HELMET("A helmet.", 8833),
+	SALMON_OR_TROUT("A fish.", 8829),
+	SPADE("A spade.", 8837);
+
+	private final String optionText;
+	private final int modelID;
+
+	private static final Map<Integer, CerterEventItem> ITEM_MODEL_ID_MAP;
+
+	static
+	{
+		ImmutableMap.Builder<Integer, CerterEventItem> itemModelIDBuilder = new ImmutableMap.Builder<>();
+
+		for (CerterEventItem certerEventItem : values())
+		{
+			itemModelIDBuilder.put(certerEventItem.getModelID(), certerEventItem);
+		}
+
+		ITEM_MODEL_ID_MAP = itemModelIDBuilder.build();
+	}
+
+	private static final Map<String, CerterEventItem> ITEM_OPTION_TEXT_MAP;
+
+	static
+	{
+		ImmutableMap.Builder<String, CerterEventItem> itemOptionTextBuilder = new ImmutableMap.Builder<>();
+
+		for (CerterEventItem certerEventItem : values())
+		{
+			itemOptionTextBuilder.put(certerEventItem.getOptionText(), certerEventItem);
+		}
+
+		ITEM_OPTION_TEXT_MAP = itemOptionTextBuilder.build();
+	}
+
+	public static CerterEventItem fromModelID(int modelID)
+	{
+		return ITEM_MODEL_ID_MAP.get(modelID);
+	}
+
+	public static CerterEventItem fromOptionText(String optionText)
+	{
+		return ITEM_OPTION_TEXT_MAP.get(optionText);
+	}
+
+	@Override
+	public String toString()
+	{
+		return String.format("%s (\"%s\" | Model ID: %d)", this.name(), this.optionText, this.modelID);
+	}
+}

--- a/src/main/java/randomeventhelper/randomevents/certer/CerterHelper.java
+++ b/src/main/java/randomeventhelper/randomevents/certer/CerterHelper.java
@@ -1,0 +1,141 @@
+package randomeventhelper.randomevents.certer;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.events.WidgetClosed;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
+import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.pluginmodulesystem.PluginModule;
+
+@Slf4j
+@Singleton
+public class CerterHelper extends PluginModule
+{
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private CerterOverlay certerOverlay;
+
+	@Getter
+	private Widget certerAnswerWidget;
+
+	private final int[] CERTER_OPTION_WIDGETS = {
+		InterfaceID.MacroCerter.MACRO_CERTER_A,
+		InterfaceID.MacroCerter.MACRO_CERTER_B,
+		InterfaceID.MacroCerter.MACRO_CERTER_C,
+	};
+
+	private final int[] CERTER_OPTION_TEXT_WIDGETS = {
+		InterfaceID.MacroCerter.MACRO_CERTER_TEXTA,
+		InterfaceID.MacroCerter.MACRO_CERTER_TEXTB,
+		InterfaceID.MacroCerter.MACRO_CERTER_TEXTC,
+	};
+
+	@Inject
+	public CerterHelper(OverlayManager overlayManager, RandomEventHelperConfig config, Client client)
+	{
+		super(overlayManager, config, client);
+	}
+
+	@Override
+	public void onStartUp()
+	{
+		this.overlayManager.add(certerOverlay);
+		this.certerAnswerWidget = null;
+
+		if (this.isLoggedIn())
+		{
+			this.clientThread.invokeLater(() -> {
+				if (this.client.getWidget(InterfaceID.MacroCerter.MACRO_CERTER_ITEM) != null)
+				{
+					WidgetLoaded certerItemWidgetLoaded = new WidgetLoaded();
+					certerItemWidgetLoaded.setGroupId(InterfaceID.MACRO_CERTER);
+					this.eventBus.post(certerItemWidgetLoaded);
+				}
+			});
+		}
+	}
+
+	@Override
+	public void onShutdown()
+	{
+		this.eventBus.unregister(this);
+		this.overlayManager.remove(certerOverlay);
+		this.certerAnswerWidget = null;
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.config.isCerterEnabled();
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded widgetLoaded)
+	{
+		if (widgetLoaded.getGroupId() == InterfaceID.MACRO_CERTER)
+		{
+			log.debug("Player has opened the Certer random event widget");
+			this.clientThread.invokeLater(() -> {
+				CerterEventItem certerEventItem = null;
+				Widget certerItemWidget = this.client.getWidget(InterfaceID.MacroCerter.MACRO_CERTER_ITEM);
+				if (certerItemWidget != null && !certerItemWidget.isHidden())
+				{
+					certerEventItem = CerterEventItem.fromModelID(certerItemWidget.getModelId());
+					if (certerEventItem != null)
+					{
+						log.debug("Determined the required item for the Certer: {}", certerEventItem);
+						// We'll handle fetching and setting the answer widget later
+					}
+					else
+					{
+						log.debug("Couldn't the item model ID {} to any CerterEventItem", certerItemWidget.getModelId());
+						return;
+					}
+				}
+
+				for (int i = 0; i < CERTER_OPTION_TEXT_WIDGETS.length; i++)
+				{
+					Widget optionWidget = this.client.getWidget(CERTER_OPTION_TEXT_WIDGETS[i]);
+					if (optionWidget != null && !optionWidget.isHidden())
+					{
+						String optionText = Text.sanitizeMultilineText(optionWidget.getText());
+						char optionLetter = (char) ('A' + i);
+						log.debug("Certer option widget '{}' with text: \"{}\"", optionLetter, optionText);
+						if (certerEventItem != null && certerEventItem.getOptionText().equals(optionText))
+						{
+							this.certerAnswerWidget = this.client.getWidget(this.CERTER_OPTION_WIDGETS[i]);
+							log.debug("Found answer {}. \"{}\" given the CerterEventItem: {}", optionLetter, optionText, certerEventItem);
+							return;
+						}
+					}
+				}
+			});
+		}
+	}
+
+	@Subscribe
+	public void onWidgetClosed(WidgetClosed widgetClosed)
+	{
+		if (widgetClosed.getGroupId() == InterfaceID.MACRO_CERTER)
+		{
+			log.debug("Player has closed the Certer random event widget, clearing last known answer");
+			this.certerAnswerWidget = null;
+		}
+	}
+}

--- a/src/main/java/randomeventhelper/randomevents/certer/CerterOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/certer/CerterOverlay.java
@@ -1,0 +1,40 @@
+package randomeventhelper.randomevents.certer;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+@Slf4j
+@Singleton
+public class CerterOverlay extends Overlay
+{
+	private final Client client;
+	private final CerterHelper plugin;
+
+	@Inject
+	public CerterOverlay(Client client, CerterHelper plugin)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics2D)
+	{
+		if (this.plugin.getCerterAnswerWidget() != null && !this.plugin.getCerterAnswerWidget().isHidden())
+		{
+			OverlayUtil.renderPolygon(graphics2D, this.plugin.getCerterAnswerWidget().getBounds(), Color.GREEN);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
### feat(certer): Add support for the Certer random event (#45)

- Created a new PluginModule class CerterHelper to help manage the Certer random event logic
- Created a new Overlay class CerterOverlay to display the relevant overlay for the Certer random event
- Created a new Enum CerterEventItem to represent the various items associated with the Certer random event
- Updated the main plugin class RandomEventHelperPlugin to inject and enable CerterHelper
- Updated the plugin config with an option to toggle the Certer random event module
	- Additionally re-sorted the config options

Completes one request made within #45 for additional solver support.
Already tested and validated to be working with Giles and Miles, and safe to assume Niles as well. Though I did git stash it and switch it to a new branch, so hopefully I didn't break anything...


https://github.com/user-attachments/assets/91eb28a1-cd52-4837-9751-5f055f14b480


<img width="966" height="700" alt="image" src="https://github.com/user-attachments/assets/d28cf029-981c-44dd-b28c-848b9e69fe2d" />

