### PR TITLE
[Surprise Exam] Fix matching card question hint for "hand-to-hand"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.4.0'
+version = '3.4.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -71,7 +71,7 @@ public class OSRSItemRelationshipSystem
 		Map.entry("water", Set.of("fishing", "fish", "seafood", "ocean", "sea")),
 		Map.entry("sea", Set.of("fishing", "fish", "pirate", "nautical", "ocean")),
 		Map.entry("dragon", Set.of("combat", "weapon", "battle", "fighting")),
-		Map.entry("sword", Set.of("melee", "weapon", "combat", "blade")),
+		Map.entry("sword", Set.of("melee", "weapon", "combat", "blade", "hand-to-hand")),
 		Map.entry("bow", Set.of("range", "weapon", "arrow", "ammunition")),
 		Map.entry("spell", Set.of("magic", "runes", "staff", "runecrafting")),
 		Map.entry("food", Set.of("cooking", "chef", "meal", "kitchen")),
@@ -115,64 +115,6 @@ public class OSRSItemRelationshipSystem
 	{
 		this.relationships = initializeRelationships();
 		this.jaroWinklerDistance = new JaroWinklerDistance();
-	}
-
-	/**
-	 * Detects tokens in the riddle that are likely negated.
-	 *
-	 * <p>
-	 * This method analyzes the riddle text and identifies words that appear to be
-	 * negated by phrases such as <i>no</i>, <i>not</i>, <i>without</i>, or <i>hate</i>.
-	 * These tokens can then be excluded from further matching logic.
-	 * </p>
-	 *
-	 * <p><b>Example</b></p>
-	 * <pre>
-	 * Input:
-	 *   "Tools for warriors who hate ranging or magic."
-	 *
-	 * Output:
-	 *   ["ranging", "magic"]
-	 * </pre>
-	 *
-	 * @param riddle The riddle or hint text to analyze.
-	 * @return A {@code Set<String>} containing tokens that are likely negated within the provided riddle text.
-	 */
-	private Set<String> detectNegatedTokens(String riddle)
-	{
-		Set<String> negated = new HashSet<>();
-		if (riddle == null || riddle.isEmpty())
-		{
-			return negated;
-		}
-
-		String cleanRiddle = riddle.toLowerCase().replaceAll("[^a-zA-Z\\s]", " ").replaceAll("\\s+", " ").trim();
-		String[] tokens = cleanRiddle.split("\\s+");
-
-		for (int i = 0; i < tokens.length; i++)
-		{
-			String t = tokens[i];
-			if (NEGATION_WORDS.contains(t))
-			{
-				// look forward up to 4 tokens for possible negated tokens
-				for (int j = i + 1; j < Math.min(tokens.length, i + 5); j++)
-				{
-					String nt = tokens[j];
-					if (STOP_WORDS.contains(nt) || NEGATION_WORDS.contains(nt) || nt.equals("or") || nt.equals("and"))
-					{
-						// skip connector words and break if we encounter another negation
-						if (nt.equals("or") || nt.equals("and"))
-						{
-							continue;
-						}
-						break;
-					}
-					negated.add(nt);
-				}
-			}
-		}
-
-		return negated;
 	}
 
 	private Map<RelationshipType, Set<RandomEventItem>> initializeRelationships()
@@ -734,7 +676,7 @@ public class OSRSItemRelationshipSystem
 
 		// Clean and split the riddle
 		String cleanRiddle = riddle.toLowerCase()
-			.replaceAll("[^a-zA-Z\\s]", " ") // Remove punctuation
+			.replaceAll("[^a-zA-Z\\s-]", " ") // Remove punctuation
 			.replaceAll("\\s+", " ") // Normalize whitespace
 			.trim();
 
@@ -778,6 +720,64 @@ public class OSRSItemRelationshipSystem
 		}
 
 		return expandedKeywords;
+	}
+
+	/**
+	 * Detects tokens in the riddle that are likely negated.
+	 *
+	 * <p>
+	 * This method analyzes the riddle text and identifies words that appear to be
+	 * negated by phrases such as <i>no</i>, <i>not</i>, <i>without</i>, or <i>hate</i>.
+	 * These tokens can then be excluded from further matching logic.
+	 * </p>
+	 *
+	 * <p><b>Example</b></p>
+	 * <pre>
+	 * Input:
+	 *   "Tools for warriors who hate ranging or magic."
+	 *
+	 * Output:
+	 *   ["ranging", "magic"]
+	 * </pre>
+	 *
+	 * @param riddle The riddle or hint text to analyze.
+	 * @return A {@code Set<String>} containing tokens that are likely negated within the provided riddle text.
+	 */
+	private Set<String> detectNegatedTokens(String riddle)
+	{
+		Set<String> negated = new HashSet<>();
+		if (riddle == null || riddle.isEmpty())
+		{
+			return negated;
+		}
+
+		String cleanRiddle = riddle.toLowerCase().replaceAll("[^a-zA-Z\\s]", " ").replaceAll("\\s+", " ").trim();
+		String[] tokens = cleanRiddle.split("\\s+");
+
+		for (int i = 0; i < tokens.length; i++)
+		{
+			String t = tokens[i];
+			if (NEGATION_WORDS.contains(t))
+			{
+				// look forward up to 4 tokens for possible negated tokens
+				for (int j = i + 1; j < Math.min(tokens.length, i + 5); j++)
+				{
+					String nt = tokens[j];
+					if (STOP_WORDS.contains(nt) || NEGATION_WORDS.contains(nt) || nt.equals("or") || nt.equals("and"))
+					{
+						// skip connector words and break if we encounter another negation
+						if (nt.equals("or") || nt.equals("and"))
+						{
+							continue;
+						}
+						break;
+					}
+					negated.add(nt);
+				}
+			}
+		}
+
+		return negated;
 	}
 
 	private RandomEventItem findMissingItemByPartialMatch(List<RandomEventItem> knownItems, List<RandomEventItem> candidates)

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -190,6 +190,22 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle22ActualItems = relationshipSystem.findItemsByHint(puzzle22.getHint(), puzzle22.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle22ActualItems).containsExactlyInAnyOrderElementsOf(puzzle22.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle23 = new RelationshipSystemTestMatchingData(
+			"Does this pattern leap out at you like magic?",
+			"[TROUT_COD_PIKE_SALMON_3, PIRATE_HAT, CUP_OF_TEA, TINDERBOX, BATTLE_AXE, MED_HELM, FIRE_RUNE, BOTTLE, GARDENING_TROWEL, NEEDLE, PIRATE_HOOK, STAFF, WATER_RUNE, INSULATED_BOOTS, EYE_PATCH]",
+			List.of(RandomEventItem.FIRE_RUNE, RandomEventItem.STAFF, RandomEventItem.WATER_RUNE)
+		);
+		List<RandomEventItem> puzzle23ActualItems = relationshipSystem.findItemsByHint(puzzle23.getHint(), puzzle23.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle23ActualItems).containsExactlyInAnyOrderElementsOf(puzzle23.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle24 = new RelationshipSystemTestMatchingData(
+			"There's nothing better than going hand-to-hand with these patterns.",
+			"[INSULATED_BOOTS, CROSSBOW, TROUT_COD_PIKE_SALMON_3, BOTTLE, BATTLE_AXE, BEER, LONGSWORD, RAKE, LOGS, POT, RUNE_OR_ESSENCE, SCIMITAR, BONES, NEEDLE, BAR]",
+			List.of(RandomEventItem.BATTLE_AXE, RandomEventItem.LONGSWORD, RandomEventItem.SCIMITAR)
+		);
+		List<RandomEventItem> puzzle24ActualItems = relationshipSystem.findItemsByHint(puzzle24.getHint(), puzzle24.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle24ActualItems).containsExactlyInAnyOrderElementsOf(puzzle24.getExpectedMatchingItems());
 	}
 
 	@Test
@@ -347,6 +363,22 @@ public class RelationshipSystemTest
 		);
 		RandomEventItem puzzle19ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle19.getInitialSequenceItems(), puzzle19.getItemChoices());
 		Assertions.assertThat(puzzle19ActualNextMissingItem).isEqualTo(puzzle19.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle20 = new RelationshipSystemTestNextMissingItemData(
+			"[HIGHWAYMAN_MASK, JESTER_HAT, PIRATE_HAT]",
+			"[PICKAXE, BREAD, LEDERHOSEN_HAT, CAKE]",
+			RandomEventItem.LEDERHOSEN_HAT
+		);
+		RandomEventItem puzzle20ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle20.getInitialSequenceItems(), puzzle20.getItemChoices());
+		Assertions.assertThat(puzzle20ActualNextMissingItem).isEqualTo(puzzle20.getExpectedNextMissingItem());
+
+		RelationshipSystemTestNextMissingItemData puzzle21 = new RelationshipSystemTestNextMissingItemData(
+			"[GARDENING_TROWEL, WATERING_CAN, SPADE]",
+			"[CAKE, WATER_RUNE, FIRE_RUNE, RAKE]",
+			RandomEventItem.RAKE
+		);
+		RandomEventItem puzzle21ActualNextMissingItem = relationshipSystem.findMissingItem(puzzle21.getInitialSequenceItems(), puzzle21.getItemChoices());
+		Assertions.assertThat(puzzle21ActualNextMissingItem).isEqualTo(puzzle21.getExpectedNextMissingItem());
 	}
 
 	@Data


### PR DESCRIPTION
### fix(surpriseexam): Fix matching card question hint for "going hand-to-hand"

- Fixed the incorrect matching card pattern hint for "There's nothing better than going hand-to-hand with these patterns."
- Added new keyword "hand-to-hand" to CONTEXT_CLUES as a context clue for "sword"
- Modified regex used within OSRSItemRelationshipSystem#extractRiddleKeywords to not remove `-` punctuation
- Added new test cases to testPatternMatching and testNextMissingItem

Thanks to @Rickness666 for reporting the incorrect question.

_Also, I moved #detectNegatedTokens further down the file._