### PR TITLE
[Surprise Exam] Fix matching card question hint for "wizardry"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.4.1'
+version = '3.4.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/RelationshipType.java
@@ -10,7 +10,7 @@ public enum RelationshipType
 	FARMING_ECOSYSTEM("farming, agriculture, rake, seeds, crops, harvest, plants"),
 	COOKING_PRODUCTION("cooking, food, chef, kitchen, bread, cake, meals"),
 	ALCOHOL_PRODUCTION("alcohol, brewing, cocktail, beer, rum, gin, drinks"),
-	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus"),
+	MAGIC_RUNECRAFTING("magic, runecrafting, runes, essence, spells, staff, abracadabra, hocus pocus, wizard"),
 	JEWELRY_CRAFTING("jewelry, gems, necklace, ring, crafting, status, shiny, precious, wearing all your bangles, bobbles and fineries, accessory, accessories, silver, gold"),
 	LIGHT_FIRE_SYSTEM("fire, light, candle, lantern, tinderbox, illumination, ignite, igniting"),
 	CONTAINER_STORAGE("container, storage, bottle, jug, pot, holding"),

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -206,6 +206,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle24ActualItems = relationshipSystem.findItemsByHint(puzzle24.getHint(), puzzle24.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle24ActualItems).containsExactlyInAnyOrderElementsOf(puzzle24.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle25 = new RelationshipSystemTestMatchingData(
+			"There is wizardry here!",
+			"[EYE_PATCH, TINDERBOX, MED_HELM, CUP_OF_TEA, TROUT_COD_PIKE_SALMON_3, PIRATE_HOOK, NEEDLE, PIRATE_HAT, FIRE_RUNE, STAFF, BOTTLE, WATER_RUNE, GARDENING_TROWEL, BATTLE_AXE, INSULATED_BOOTS]",
+			List.of(RandomEventItem.FIRE_RUNE, RandomEventItem.STAFF, RandomEventItem.WATER_RUNE)
+		);
+		List<RandomEventItem> puzzle25ActualItems = relationshipSystem.findItemsByHint(puzzle25.getHint(), puzzle25.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle25ActualItems).containsExactlyInAnyOrderElementsOf(puzzle25.getExpectedMatchingItems());
 	}
 
 	@Test


### PR DESCRIPTION
### fix(surpriseexam): Fix matching card question hint for "wizardry here"

- Fixed the incorrect matching card pattern hint for "There is wizardry here!"
- Added new keyword "wizard" to the MAGIC_RUNECRAFTING RelationshipType
- Added new test case to testPatternMatching

### chore: Update plugin to v3.4.2

- Fixed Surprise Exam random event incorrect pattern matching card question
	- "There is wizardry here!"

Thanks to @ThatOneCamel for reporting the incorrect question.