### PR TITLE
fix(surpriseexam): Fix matching card question hint for "burn"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.5.0'
+version = '3.5.1'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/OSRSItemRelationshipSystem.java
@@ -95,7 +95,8 @@ public class OSRSItemRelationshipSystem
 		"pirate", Set.of("buccaneer", "seafarer", "mariner", "sailor", "nautical"),
 		"drink", Set.of("beverage", "liquid", "fluid", "potion", "brew", "sip"),
 		"tool", Set.of("equipment", "implement", "instrument", "utility", "gear"),
-		"bow", Set.of("archery", "ranged", "range", "arrow", "archer", "crossbow")
+		"bow", Set.of("archery", "ranged", "range", "arrow", "archer", "crossbow"),
+		"fire", Set.of("light", "burn", "ignite", "flame", "heat")
 	);
 
 	// Negation words and a small map to suggest opposite relationships for negated keywords

--- a/src/test/java/randomeventhelper/RelationshipSystemTest.java
+++ b/src/test/java/randomeventhelper/RelationshipSystemTest.java
@@ -214,6 +214,14 @@ public class RelationshipSystemTest
 		);
 		List<RandomEventItem> puzzle25ActualItems = relationshipSystem.findItemsByHint(puzzle25.getHint(), puzzle25.getGivenItems(), 3).subList(0, 3);
 		Assertions.assertThat(puzzle25ActualItems).containsExactlyInAnyOrderElementsOf(puzzle25.getExpectedMatchingItems());
+
+		RelationshipSystemTestMatchingData puzzle26 = new RelationshipSystemTestMatchingData(
+			"When you just want to watch the world burn...",
+			"[BOTTLE, TINDERBOX, KEY, LEDERHOSEN_HAT, LONGSWORD, LOGS, PICKAXE, CUP_OF_TEA, HAMMER, CANDLE_LANTERN, TUNA, WATERING_CAN, TROUT_COD_PIKE_SALMON_3, GEM_WITH_CROSS, HARPOON]",
+			List.of(RandomEventItem.TINDERBOX, RandomEventItem.LOGS, RandomEventItem.CANDLE_LANTERN)
+		);
+		List<RandomEventItem> puzzle26ActualItems = relationshipSystem.findItemsByHint(puzzle26.getHint(), puzzle26.getGivenItems(), 3).subList(0, 3);
+		Assertions.assertThat(puzzle26ActualItems).containsExactlyInAnyOrderElementsOf(puzzle26.getExpectedMatchingItems());
 	}
 
 	@Test


### PR DESCRIPTION
### fix(surpriseexam): Fix matching card question hint for "world burn"

- Fixed the incorrect matching card pattern hint for "When you just want to watch the world burn..."
- Added new entry "fire" to the SYNONYMS map within the OSRSItemRelationshipSystem
- Added new test case to testPatternMatching


### chore: Update plugin to v3.5.1

- Fixed Surprise Exam random event incorrect pattern matching card question
	- "When you just want to watch the world burn..."