### PR TITLE
feat: Add custom color fill highlighting option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ test {
 }
 
 group = 'randomeventhelper'
-version = '3.5.1'
+version = '3.6.0'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/RandomEventHelperConfig.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperConfig.java
@@ -2,6 +2,7 @@ package randomeventhelper;
 
 import java.awt.Color;
 import java.util.Set;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -214,13 +215,26 @@ public interface RandomEventHelperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightColor",
-		name = "Highlight Color",
-		description = "Configures the color used for highlighting the solutions to the various random events.<br>Note, this excludes the Gravedigger highlights.",
+		keyName = "borderColor",
+		name = "Border Color",
+		description = "Configures the border color used for highlighting the solutions to the various random events.<br>Note, this excludes the Gravedigger highlights.",
 		position = 13
 	)
-	default Color highlightColor()
+	@Alpha
+	default Color borderColor()
 	{
 		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		keyName = "fillColor",
+		name = "Fill Color",
+		description = "Configures the fill color used for highlighting the solutions to the various random events.<br>Note, this excludes the Gravedigger highlights.",
+		position = 14
+	)
+	@Alpha
+	default Color fillColor()
+	{
+		return new Color(Color.GREEN.getRed(), Color.GREEN.getGreen(), Color.GREEN.getBlue(), 50);
 	}
 }

--- a/src/main/java/randomeventhelper/RandomEventHelperOverlay.java
+++ b/src/main/java/randomeventhelper/RandomEventHelperOverlay.java
@@ -1,13 +1,17 @@
 package randomeventhelper;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Shape;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 
 public class RandomEventHelperOverlay extends Overlay
@@ -33,5 +37,10 @@ public class RandomEventHelperOverlay extends Overlay
 	public Dimension render(Graphics2D graphics2D)
 	{
 		return null;
+	}
+
+	public static void renderOverlayWithFill(Graphics2D graphics, Shape poly, Color borderColor, Color fillColor)
+	{
+		OverlayUtil.renderPolygon(graphics, poly, borderColor, fillColor, new BasicStroke(2));
 	}
 }

--- a/src/main/java/randomeventhelper/randomevents/certer/CerterOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/certer/CerterOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.certer;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -10,8 +9,8 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -36,7 +35,7 @@ public class CerterOverlay extends Overlay
 	{
 		if (this.plugin.getCerterAnswerWidget() != null && !this.plugin.getCerterAnswerWidget().isHidden())
 		{
-			OverlayUtil.renderPolygon(graphics2D, this.plugin.getCerterAnswerWidget().getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getCerterAnswerWidget().getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}

--- a/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/drilldemon/DrillDemonOverlay.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.GroundObject;
 import net.runelite.client.ui.overlay.Overlay;
@@ -16,6 +15,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -47,7 +47,7 @@ public class DrillDemonOverlay extends Overlay
 			{
 				if (exerciseGroundObject != null)
 				{
-					OverlayUtil.renderPolygon(graphics2D, combinedMatHull, this.config.highlightColor());
+					RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, combinedMatHull, this.config.borderColor(), this.config.fillColor());
 				}
 			}
 		}

--- a/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/freakyforester/FreakyForesterOverlay.java
@@ -14,6 +14,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -41,7 +42,7 @@ public class FreakyForesterOverlay extends Overlay
 			case SPECIFIC:
 				if (plugin.getSpecificPheasantNPC() != null && !plugin.getSpecificPheasantNPC().isDead())
 				{
-					OverlayUtil.renderPolygon(graphics2D, plugin.getSpecificPheasantNPC().getConvexHull(), this.config.highlightColor());
+					RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getSpecificPheasantNPC().getConvexHull(), this.config.borderColor(), this.config.fillColor());
 				}
 				else if (plugin.getSpecificPheasantNPC() == null && plugin.getFreakyForesterNPC() != null)
 				{
@@ -51,7 +52,7 @@ public class FreakyForesterOverlay extends Overlay
 			case NEAREST:
 				if (plugin.getNearestPheasantNPC() != null && !plugin.getNearestPheasantNPC().isDead())
 				{
-					OverlayUtil.renderPolygon(graphics2D, plugin.getNearestPheasantNPC().getConvexHull(), this.config.highlightColor());
+					RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getNearestPheasantNPC().getConvexHull(), this.config.borderColor(), this.config.fillColor());
 				}
 				break;
 			case ALL:
@@ -59,7 +60,7 @@ public class FreakyForesterOverlay extends Overlay
 				{
 					if (pheasantNPC != null && !pheasantNPC.isDead())
 					{
-						OverlayUtil.renderPolygon(graphics2D, pheasantNPC.getConvexHull(), this.config.highlightColor());
+						RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, pheasantNPC.getConvexHull(), this.config.borderColor(), this.config.fillColor());
 					}
 				}
 				break;

--- a/src/main/java/randomeventhelper/randomevents/frog/FrogOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/frog/FrogOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.frog;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -8,8 +7,8 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 public class FrogOverlay extends Overlay
 {
@@ -32,7 +31,7 @@ public class FrogOverlay extends Overlay
 	{
 		if (this.plugin.isEventActiveForPlayer() && this.plugin.getCrownedFrogNPC() != null)
 		{
-			OverlayUtil.renderPolygon(graphics2D, this.plugin.getCrownedFrogNPC().getConvexHull(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getCrownedFrogNPC().getConvexHull(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}

--- a/src/main/java/randomeventhelper/randomevents/mime/MimeOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/mime/MimeOverlay.java
@@ -3,21 +3,17 @@ package randomeventhelper.randomevents.mime;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
-import net.runelite.api.gameval.InterfaceID;
-import net.runelite.api.widgets.Widget;
-import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
-import randomeventhelper.randomevents.gravedigger.GravediggerHelper;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -43,8 +39,9 @@ public class MimeOverlay extends Overlay
 	{
 		if (plugin.getMimeEmoteAnswerWidget() != null && !plugin.getMimeEmoteAnswerWidget().isHidden())
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getMimeEmoteAnswerWidget().getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getMimeEmoteAnswerWidget().getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
+
 		if (plugin.getMimeNPC() != null)
 		{
 			String mimeEmoteText = plugin.getCurrentMimeEmote() != null ? plugin.getCurrentMimeEmote().name() : "Waiting for emote";

--- a/src/main/java/randomeventhelper/randomevents/pinball/PinballOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/pinball/PinballOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.pinball;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -10,8 +9,8 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -36,7 +35,7 @@ public class PinballOverlay extends Overlay
 	{
 		if (plugin.getActivePinballPost() != null)
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getActivePinballPost().getConvexHull(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getActivePinballPost().getConvexHull(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}

--- a/src/main/java/randomeventhelper/randomevents/pirate/PirateOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/pirate/PirateOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.pirate;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -11,9 +10,8 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
-import randomeventhelper.randomevents.mime.MimeHelper;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -40,9 +38,10 @@ public class PirateOverlay extends Overlay
 		{
 			return null;
 		}
+
 		if (plugin.getPirateChestSolver().isSolved())
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getWidgetMap().get(PirateHelper.CONFIRM_BUTTON_WIDGET_ID).getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getWidgetMap().get(PirateHelper.CONFIRM_BUTTON_WIDGET_ID).getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
 		else
 		{
@@ -51,15 +50,15 @@ public class PirateOverlay extends Overlay
 			Widget rightActionWidget = plugin.getWidgetMap().get(plugin.getPirateChestSolver().getRightSlotUseWidget());
 			if (leftActionWidget != null)
 			{
-				OverlayUtil.renderPolygon(graphics2D, leftActionWidget.getBounds(), this.config.highlightColor());
+				RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, leftActionWidget.getBounds(), this.config.borderColor(), this.config.fillColor());
 			}
 			if (centerActionWidget != null)
 			{
-				OverlayUtil.renderPolygon(graphics2D, centerActionWidget.getBounds(), this.config.highlightColor());
+				RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, centerActionWidget.getBounds(), this.config.borderColor(), this.config.fillColor());
 			}
 			if (rightActionWidget != null)
 			{
-				OverlayUtil.renderPolygon(graphics2D, rightActionWidget.getBounds(), this.config.highlightColor());
+				RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, rightActionWidget.getBounds(), this.config.borderColor(), this.config.fillColor());
 			}
 		}
 		return null;

--- a/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/quizmaster/QuizMasterOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.quizmaster;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -10,8 +9,8 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -36,7 +35,7 @@ public class QuizMasterOverlay extends Overlay
 	{
 		if (plugin.getQuizAnswerWidget() != null && !plugin.getQuizAnswerWidget().isHidden())
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getQuizAnswerWidget().getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getQuizAnswerWidget().getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}

--- a/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichLadyOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.sandwichlady;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -10,8 +9,8 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -36,7 +35,7 @@ public class SandwichLadyOverlay extends Overlay
 	{
 		if (plugin.getTrayFoodAnswerWidget() != null && !plugin.getTrayFoodAnswerWidget().isHidden())
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getTrayFoodAnswerWidget().getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getTrayFoodAnswerWidget().getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}

--- a/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamOverlay.java
+++ b/src/main/java/randomeventhelper/randomevents/surpriseexam/SurpriseExamOverlay.java
@@ -1,6 +1,5 @@
 package randomeventhelper.randomevents.surpriseexam;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -11,8 +10,8 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import randomeventhelper.RandomEventHelperConfig;
+import randomeventhelper.RandomEventHelperOverlay;
 
 @Slf4j
 @Singleton
@@ -41,14 +40,14 @@ public class SurpriseExamOverlay extends Overlay
 			{
 				if (answerWidget != null && !answerWidget.isHidden())
 				{
-					OverlayUtil.renderPolygon(graphics2D, answerWidget.getBounds(), this.config.highlightColor());
+					RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, answerWidget.getBounds(), this.config.borderColor(), this.config.fillColor());
 				}
 			}
 		}
 
 		if (plugin.getPatternNextAnswerWidget() != null)
 		{
-			OverlayUtil.renderPolygon(graphics2D, plugin.getPatternNextAnswerWidget().getBounds(), this.config.highlightColor());
+			RandomEventHelperOverlay.renderOverlayWithFill(graphics2D, this.plugin.getPatternNextAnswerWidget().getBounds(), this.config.borderColor(), this.config.fillColor());
 		}
 		return null;
 	}


### PR DESCRIPTION
### feat: Add custom color fill highlighting option

- Added wrapper method RandomEventHelperOverlay#renderOverlayWithFill to help highlight polygons with a custom border and fill color
- Added a new config option fillColor to allow users to specify their own fill color for solution highlighting
- Renamed old highlightColor config option to borderColor
- Added `@Alpha` to color config options to support opacity within the color picker
- Modified the overlays for various event modules to use the new render helper method highlighting the solutions

### chore: Update plugin to v3.6.0

- Added the ability for users to specify their own fill color for solution highlighting

<img width="1271" height="732" alt="image" src="https://github.com/user-attachments/assets/52e49ed3-cfcc-40e7-b7b6-c1d175aacfba" />
